### PR TITLE
feat: add storage manager backend

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -42,7 +42,7 @@ Comprehensive error handling with proper HTTP status codes:
 - `AuthenticationException` (401) - Authentication required
 - `ConflictException` (409) - Resource conflict
 - `PreconditionFailedException` (412) - Precondition failed
-- `RequestTooLargeException` (413) - Request entity too large
+- `ContentTooLargeException` (413) - Request entity too large
 - `CollectionNotFoundException` (404) - Collection not found
 - `QuotaExceededException` (507) - Storage quota exceeded
 
@@ -87,7 +87,6 @@ class NewRoute(BaseRoute):
 
 All route implementations currently contain TODO comments for:
 - Authentication validation integration
-- Backend storage implementation (likely DynamoDB)
 - Proper timestamp generation
 - Request payload parsing and validation
 - Response header management (X-Last-Modified, X-If-Unmodified-Since)

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,3 +1,4 @@
 aws-lambda-proxy==1.1.1
 aws-lambda-powertools==3.23.0
+boto3==1.42.2
 dataclasses-json==0.6.7

--- a/lambda/src/environment/service_provider.py
+++ b/lambda/src/environment/service_provider.py
@@ -1,5 +1,7 @@
+import os
 from functools import cached_property
 
+import boto3
 from src.routes.bso.delete import DeleteBSORoute
 from src.routes.bso.read import ReadBSORoute
 from src.routes.bso.update import UpdateBSORoute
@@ -14,26 +16,42 @@ from src.routes.info.read_quota import ReadQuotaInfoRoute
 from src.routes.info.read_usage import ReadCollectionUsageRoute
 from src.routes.storage.delete_all import DeleteAllStorageRoute
 from src.services.api_router import ApiRouter
+from src.services.storage_manager import StorageManager
 
 
 class ServiceProvider:
+    @cached_property
+    def aws_region(self):
+        return os.environ.get("AWS_REGION")
+
+    @cached_property
+    def session(self):
+        return boto3.Session(region_name=self.aws_region)
+
+    @cached_property
+    def table_name(self):
+        return os.environ.get("STORAGE_TABLE_NAME")
+
+    @cached_property
+    def storage_manager(self) -> StorageManager:
+        return StorageManager(session=self.session, table_name=self.table_name)
 
     @cached_property
     def api_router(self):
         return ApiRouter(
             routes=[
                 DeleteAllStorageRoute(),
-                ReadCollectionsInfoRoute(),
-                ReadCollectionCountsRoute(),
-                ReadCollectionUsageRoute(),
-                ReadQuotaInfoRoute(),
-                ListCollectionsRoute(),
-                CreateCollectionRoute(),
-                ReadCollectionRoute(),
-                UpdateCollectionRoute(),
-                DeleteCollectionRoute(),
-                ReadBSORoute(),
-                UpdateBSORoute(),
-                DeleteBSORoute(),
+                ReadCollectionsInfoRoute(self.storage_manager),
+                ReadCollectionCountsRoute(self.storage_manager),
+                ReadCollectionUsageRoute(self.storage_manager),
+                ReadQuotaInfoRoute(self.storage_manager),
+                ListCollectionsRoute(self.storage_manager),
+                CreateCollectionRoute(self.storage_manager),
+                ReadCollectionRoute(self.storage_manager),
+                UpdateCollectionRoute(self.storage_manager),
+                DeleteCollectionRoute(self.storage_manager),
+                ReadBSORoute(self.storage_manager),
+                UpdateBSORoute(self.storage_manager),
+                DeleteBSORoute(self.storage_manager),
             ]
         )

--- a/lambda/src/routes/bso/delete.py
+++ b/lambda/src/routes/bso/delete.py
@@ -1,26 +1,65 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
+from src.shared.exceptions import (
+    CollectionNotFoundException,
+    StorageObjectNotFoundException,
+    ValidationException,
+)
 
 
 class DeleteBSORoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.delete("/storage/{collectionName}/{objectId}")
+        @api.pass_event
         def handle_with_event(event):
             return self.handle(event)
 
     def handle(self, event):
         """Delete a specific storage object"""
-        # TODO: Implement authentication validation
-        # TODO: Validate collectionName against pattern ^[a-zA-Z0-9._-]+$ and length 1-32
-        # TODO: Validate objectId against pattern ^[a-zA-Z0-9._-]+$ and length 1-64
-        # TODO: Implement storage object deletion logic
-        # TODO: Return proper timestamp in response
+        try:
+            collection_name = event["pathParameters"]["collectionName"]
+            object_id = event["pathParameters"]["objectId"]
 
-        collection_name = event["pathParameters"]["collectionName"]
-        object_id = event["pathParameters"]["objectId"]
+            # Delete storage object using DynamoDB service
+            modified_timestamp = self.dynamodb_service.delete_storage_object(
+                collection_name, object_id
+            )
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body='{"modified": 1642678800000}',
-        )
+            response_body = {"modified": modified_timestamp}
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except ValidationException as e:
+            return Response(
+                status_code=StatusCode.BAD_REQUEST,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except CollectionNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except StorageObjectNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/bso/read.py
+++ b/lambda/src/routes/bso/read.py
@@ -1,8 +1,19 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
+from src.shared.exceptions import (
+    CollectionNotFoundException,
+    StorageObjectNotFoundException,
+    ValidationException,
+)
 
 
 class ReadBSORoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.get("/storage/{collectionName}/{objectId}")
         @api.pass_event
@@ -11,18 +22,59 @@ class ReadBSORoute(BaseRoute):
 
     def handle(self, event):
         """Get a specific storage object"""
-        # TODO: Implement authentication validation
-        # TODO: Validate collectionName against pattern ^[a-zA-Z0-9._-]+$ and length 1-32
-        # TODO: Validate objectId against pattern ^[a-zA-Z0-9._-]+$ and length 1-64
-        # TODO: Implement storage object retrieval logic
-        # TODO: Return proper X-Last-Modified header
+        try:
+            collection_name = event["pathParameters"]["collectionName"]
+            object_id = event["pathParameters"]["objectId"]
 
-        collection_name = event["pathParameters"]["collectionName"]
-        object_id = event["pathParameters"]["objectId"]
+            # Get storage object using storage manager
+            storage_object = self.storage_manager.get_storage_object(
+                collection_name, object_id
+            )
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body=f'{{"object": {{"id": "{object_id}", "payload": "{{\\"title\\": \\"Example Object\\", \\"url\\": \\"https://example.com\\"}}", "modified": 1642678800000, "sortindex": 100}}}}',
-            headers={"X-Last-Modified": "1642678800000"},
-        )
+            response_body = {
+                "object": {
+                    "id": storage_object.id,
+                    "payload": storage_object.payload,
+                    "modified": storage_object.modified,
+                    "sortindex": storage_object.sortindex,
+                    "ttl": storage_object.ttl,
+                }
+            }
+
+            # Remove None values
+            if response_body["object"]["sortindex"] is None:
+                del response_body["object"]["sortindex"]
+            if response_body["object"]["ttl"] is None:
+                del response_body["object"]["ttl"]
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+                headers={"X-Last-Modified": str(storage_object.modified)},
+            )
+
+        except ValidationException as e:
+            return Response(
+                status_code=StatusCode.BAD_REQUEST,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except CollectionNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except StorageObjectNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/bso/update.py
+++ b/lambda/src/routes/bso/update.py
@@ -1,8 +1,21 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
+from src.shared.exceptions import (
+    CollectionNotFoundException,
+    PreconditionFailedException,
+    StorageObjectNotFoundException,
+    ValidationException,
+)
+from src.shared.models import BasicStorageObject
 
 
 class UpdateBSORoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.put("/storage/{collectionName}/{objectId}")
         @api.pass_event
@@ -11,18 +24,95 @@ class UpdateBSORoute(BaseRoute):
 
     def handle(self, event):
         """Update a storage object"""
-        # TODO: Implement authentication validation
-        # TODO: Validate collectionName against pattern ^[a-zA-Z0-9._-]+$ and length 1-32
-        # TODO: Validate objectId against pattern ^[a-zA-Z0-9._-]+$ and length 1-64
-        # TODO: Handle X-If-Unmodified-Since header for conflict prevention
-        # TODO: Implement storage object update logic
-        # TODO: Return proper modified timestamp
+        try:
+            collection_name = event["pathParameters"]["collectionName"]
+            object_id = event["pathParameters"]["objectId"]
 
-        collection_name = event["pathParameters"]["collectionName"]
-        object_id = event["pathParameters"]["objectId"]
+            # Parse object from request body
+            try:
+                body_data = json.loads(event["body"])
+                obj_data = body_data["object"]
+                storage_object = BasicStorageObject(
+                    id=obj_data["id"],
+                    payload=obj_data["payload"],
+                    sortindex=obj_data.get("sortindex"),
+                    ttl=obj_data.get("ttl"),
+                    modified=0,  # Will be set by DynamoDB service
+                )
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body=f'{{"object": {{"id": "{object_id}", "payload": "{{\\"title\\": \\"Updated Object\\", \\"url\\": \\"https://example.com\\"}}", "modified": 1642678900000, "sortindex": 100}}, "modified": 1642678900000}}',
-        )
+                # Validate that object ID in body matches path parameter
+                if storage_object.id != object_id:
+                    raise ValidationException(
+                        "Object ID in body must match path parameter"
+                    )
+
+            except (json.JSONDecodeError, KeyError) as e:
+                raise ValidationException(f"Invalid request body: {e}")
+
+            # Handle conditional update header
+            if_unmodified_since = None
+            headers = event.get("headers", {})
+            if "X-If-Unmodified-Since" in headers:
+                try:
+                    if_unmodified_since = int(headers["X-If-Unmodified-Since"])
+                except ValueError:
+                    raise ValidationException("Invalid X-If-Unmodified-Since header")
+
+            # Update storage object using DynamoDB service
+            updated_object = self.dynamodb_service.update_storage_object(
+                collection_name, object_id, storage_object, if_unmodified_since
+            )
+
+            response_body = {
+                "object": {
+                    "id": updated_object.id,
+                    "payload": updated_object.payload,
+                    "modified": updated_object.modified,
+                    "sortindex": updated_object.sortindex,
+                    "ttl": updated_object.ttl,
+                },
+                "modified": updated_object.modified,
+            }
+
+            # Remove None values
+            if response_body["object"]["sortindex"] is None:
+                del response_body["object"]["sortindex"]
+            if response_body["object"]["ttl"] is None:
+                del response_body["object"]["ttl"]
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except ValidationException as e:
+            return Response(
+                status_code=StatusCode.BAD_REQUEST,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except CollectionNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except StorageObjectNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except PreconditionFailedException as e:
+            return Response(
+                status_code=StatusCode.PRECONDITION_FAILED,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/collections/create.py
+++ b/lambda/src/routes/collections/create.py
@@ -1,8 +1,20 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
+from src.shared.exceptions import (
+    ConflictException,
+    PreconditionFailedException,
+    ValidationException,
+)
+from src.shared.models import BasicStorageObject
 
 
 class CreateCollectionRoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.post("/storage/{collectionName}")
         @api.pass_event
@@ -10,17 +22,107 @@ class CreateCollectionRoute(BaseRoute):
             return self.handle(event)
 
     def handle(self, event):
-        """Create a new collection"""
-        # TODO: Implement authentication validation
-        # TODO: Validate collectionName against pattern ^[a-zA-Z0-9._-]+$ and length 1-32
-        # TODO: Implement collection creation logic
-        # TODO: Handle batch object creation if objects provided
-        # TODO: Return proper collection data and batch result
+        """Create a new collection or batch create/update objects"""
+        try:
+            collection_name = event["pathParameters"]["collectionName"]
+            headers = event.get("headers", {})
 
-        collection_name = event["pathParameters"]["collectionName"]
+            # Check conditional headers
+            if_unmodified_since = headers.get("X-If-Unmodified-Since")
+            if if_unmodified_since and not self._check_precondition(
+                collection_name, if_unmodified_since
+            ):
+                return Response(
+                    status_code=StatusCode.PRECONDITION_FAILED,
+                    content_type="application/json",
+                    body=json.dumps({"error": "Precondition failed"}),
+                )
 
-        return Response(
-            status_code=StatusCode.CREATED,
-            content_type="application/json",
-            body=f'{{"collection": {{"name": "{collection_name}", "modified": 1642678800000, "count": 0, "usage": 0}}, "batchResult": {{"success": [], "failed": {{}}, "modified": 1642678800000}}}}',
-        )
+            # Parse objects from request body - support both direct array and wrapped object
+            objects = []
+            if event.get("body"):
+                try:
+                    body_data = json.loads(event["body"])
+
+                    # Handle direct array of objects (Mozilla API format)
+                    if isinstance(body_data, list):
+                        objects_data = body_data
+                    # Handle wrapped objects
+                    elif "objects" in body_data:
+                        objects_data = body_data["objects"]
+                    else:
+                        objects_data = []
+
+                    objects = [
+                        BasicStorageObject(
+                            id=obj["id"],
+                            payload=obj["payload"],
+                            sortindex=obj.get("sortindex"),
+                            ttl=obj.get("ttl"),
+                            modified=0,  # Will be set by storage manager
+                        )
+                        for obj in objects_data
+                    ]
+                except (json.JSONDecodeError, KeyError) as e:
+                    raise ValidationException(f"Invalid request body: {e}")
+
+            # Create/update collection using storage manager
+            collection_data, batch_result = (
+                self.storage_manager.create_or_update_collection(
+                    collection_name, objects if objects else None
+                )
+            )
+
+            response_body = {
+                "collection": {
+                    "name": collection_data.name,
+                    "modified": collection_data.modified,
+                    "count": collection_data.count,
+                    "usage": collection_data.usage,
+                },
+                "batchResult": {
+                    "success": batch_result.success,
+                    "failed": batch_result.failed,
+                    "modified": batch_result.modified,
+                },
+            }
+
+            return Response(
+                status_code=StatusCode.CREATED,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except ValidationException as e:
+            return Response(
+                status_code=StatusCode.BAD_REQUEST,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except ConflictException as e:
+            return Response(
+                status_code=StatusCode.CONFLICT,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except PreconditionFailedException as e:
+            return Response(
+                status_code=StatusCode.PRECONDITION_FAILED,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )
+
+    def _check_precondition(self, collection_name, if_unmodified_since):
+        """Check if collection was modified since given timestamp"""
+        try:
+            timestamp = float(if_unmodified_since)
+            collection = self.storage_manager.get_collection(collection_name)
+            return collection.modified <= timestamp
+        except (ValueError, Exception):
+            return True  # If we can't check, allow the operation

--- a/lambda/src/routes/collections/delete.py
+++ b/lambda/src/routes/collections/delete.py
@@ -1,8 +1,15 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
+from src.shared.exceptions import CollectionNotFoundException, ValidationException
 
 
 class DeleteCollectionRoute(BaseRoute):
+    def __init__(self, dynamodb_service: StorageManager):
+        self.dynamodb_service = dynamodb_service
+
     def bind(self, api):
         @api.delete("/storage/{collectionName}")
         @api.pass_event
@@ -11,15 +18,37 @@ class DeleteCollectionRoute(BaseRoute):
 
     def handle(self, event):
         """Delete an entire collection"""
-        # TODO: Implement authentication validation
-        # TODO: Validate collectionName against pattern ^[a-zA-Z0-9._-]+$ and length 1-32
-        # TODO: Implement collection deletion logic
-        # TODO: Return proper timestamp in response
+        try:
+            collection_name = event["pathParameters"]["collectionName"]
 
-        collection_name = event["pathParameters"]["collectionName"]
+            # Delete collection using DynamoDB service
+            modified_timestamp = self.dynamodb_service.delete_collection(
+                collection_name
+            )
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body='{"modified": 1642678800000}',
-        )
+            response_body = {"modified": modified_timestamp}
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except ValidationException as e:
+            return Response(
+                status_code=StatusCode.BAD_REQUEST,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except CollectionNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/collections/list.py
+++ b/lambda/src/routes/collections/list.py
@@ -1,8 +1,14 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
 
 
 class ListCollectionsRoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.get("/storage")
         @api.pass_event
@@ -11,12 +17,31 @@ class ListCollectionsRoute(BaseRoute):
 
     def handle(self, event):
         """List all collections with their metadata"""
-        # TODO: Implement authentication validation
-        # TODO: Implement collection listing logic
-        # TODO: Return proper CollectionDataList structure
+        try:
+            # Get collections using storage manager
+            collections = self.storage_manager.list_collections()
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body='{"collections": [{"name": "bookmarks", "modified": 1642678800000, "count": 10, "usage": 2048}, {"name": "history", "modified": 1642678900000, "count": 25, "usage": 4096}]}',
-        )
+            response_body = {
+                "collections": [
+                    {
+                        "name": collection.name,
+                        "modified": collection.modified,
+                        "count": collection.count,
+                        "usage": collection.usage,
+                    }
+                    for collection in collections
+                ]
+            }
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/collections/read.py
+++ b/lambda/src/routes/collections/read.py
@@ -1,8 +1,15 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
+from src.shared.exceptions import CollectionNotFoundException, ValidationException
 
 
 class ReadCollectionRoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.get("/storage/{collectionName}")
         @api.pass_event
@@ -10,17 +17,126 @@ class ReadCollectionRoute(BaseRoute):
             return self.handle(event)
 
     def handle(self, event):
-        """Get collection metadata"""
-        # TODO: Implement authentication validation
-        # TODO: Validate collectionName against pattern ^[a-zA-Z0-9._-]+$ and length 1-32
-        # TODO: Implement collection retrieval logic
-        # TODO: Return proper X-Last-Modified header
+        """Get collection metadata or retrieve objects with filtering"""
+        try:
+            collection_name = event["pathParameters"]["collectionName"]
+            query_params = event.get("queryStringParameters") or {}
 
-        collection_name = event["pathParameters"]["collectionName"]
+            # Check if this is a request for objects or just metadata
+            has_object_filters = any(
+                param in query_params
+                for param in [
+                    "ids",
+                    "newer",
+                    "older",
+                    "sort",
+                    "limit",
+                    "offset",
+                    "full",
+                ]
+            )
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body=f'{{"collection": {{"name": "{collection_name}", "modified": 1642678800000, "count": 10, "usage": 2048}}}}',
-            headers={"X-Last-Modified": "1642678800000"},
-        )
+            if has_object_filters:
+                # Return objects from collection with filtering
+                objects = self.storage_manager.get_collection_objects(
+                    collection_name,
+                    ids=query_params.get("ids"),
+                    newer=self._parse_timestamp(query_params.get("newer")),
+                    older=self._parse_timestamp(query_params.get("older")),
+                    sort=query_params.get("sort", "newest"),
+                    limit=self._parse_int(query_params.get("limit"), 100),
+                    offset=self._parse_int(query_params.get("offset"), 0),
+                    full=self._parse_bool(query_params.get("full", "1")),
+                )
+
+                response_body = {
+                    "objects": [
+                        self._format_object(obj) for obj in objects.get("items", [])
+                    ],
+                    "more": objects.get("more", False),
+                }
+
+                if objects.get("next_offset"):
+                    response_body["next_offset"] = objects["next_offset"]
+
+                return Response(
+                    status_code=StatusCode.OK,
+                    content_type="application/json",
+                    body=json.dumps(response_body),
+                    headers={"X-Last-Modified": str(objects.get("last_modified", 0))},
+                )
+            else:
+                # Return collection metadata only
+                collection_data = self.storage_manager.get_collection(collection_name)
+
+                response_body = {
+                    "collection": {
+                        "name": collection_data.name,
+                        "modified": collection_data.modified,
+                        "count": collection_data.count,
+                        "usage": collection_data.usage,
+                    }
+                }
+
+                return Response(
+                    status_code=StatusCode.OK,
+                    content_type="application/json",
+                    body=json.dumps(response_body),
+                    headers={"X-Last-Modified": str(collection_data.modified)},
+                )
+
+        except ValidationException as e:
+            return Response(
+                status_code=StatusCode.BAD_REQUEST,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except CollectionNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )
+
+    def _parse_timestamp(self, value):
+        """Parse timestamp from string"""
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None
+
+    def _parse_int(self, value, default):
+        """Parse integer with default"""
+        if value is None:
+            return default
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return default
+
+    def _parse_bool(self, value):
+        """Parse boolean from string"""
+        if value is None:
+            return True
+        return value.lower() in ("1", "true", "yes")
+
+    def _format_object(self, obj):
+        """Format storage object for response"""
+        result = {
+            "id": obj.id,
+            "payload": obj.payload,
+            "modified": obj.modified,
+        }
+        if obj.sortindex is not None:
+            result["sortindex"] = obj.sortindex
+        if obj.ttl is not None:
+            result["ttl"] = obj.ttl
+        return result

--- a/lambda/src/routes/collections/update.py
+++ b/lambda/src/routes/collections/update.py
@@ -1,8 +1,20 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
+from src.shared.exceptions import (
+    CollectionNotFoundException,
+    PreconditionFailedException,
+    ValidationException,
+)
+from src.shared.models import BasicStorageObject
 
 
 class UpdateCollectionRoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.put("/storage/{collectionName}")
         @api.pass_event
@@ -11,16 +23,80 @@ class UpdateCollectionRoute(BaseRoute):
 
     def handle(self, event):
         """Update collection with batch objects"""
-        # TODO: Implement authentication validation
-        # TODO: Validate collectionName against pattern ^[a-zA-Z0-9._-]+$ and length 1-32
-        # TODO: Handle X-If-Unmodified-Since header for conflict prevention
-        # TODO: Implement batch object update logic
-        # TODO: Return proper collection data and batch result
+        try:
+            collection_name = event["pathParameters"]["collectionName"]
 
-        collection_name = event["pathParameters"]["collectionName"]
+            # Parse objects from request body
+            try:
+                body_data = json.loads(event["body"])
+                objects = [
+                    BasicStorageObject(
+                        id=obj["id"],
+                        payload=obj["payload"],
+                        sortindex=obj.get("sortindex"),
+                        ttl=obj.get("ttl"),
+                        modified=0,  # Will be set by DynamoDB service
+                    )
+                    for obj in body_data["objects"]
+                ]
+            except (json.JSONDecodeError, KeyError) as e:
+                raise ValidationException(f"Invalid request body: {e}")
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body=f'{{"collection": {{"name": "{collection_name}", "modified": 1642678900000, "count": 15, "usage": 3072}}, "batchResult": {{"success": ["obj1", "obj2"], "failed": {{}}, "modified": 1642678900000}}}}',
-        )
+            # Handle conditional update header
+            if_unmodified_since = None
+            headers = event.get("headers", {})
+            if "X-If-Unmodified-Since" in headers:
+                try:
+                    if_unmodified_since = int(headers["X-If-Unmodified-Since"])
+                except ValueError:
+                    raise ValidationException("Invalid X-If-Unmodified-Since header")
+
+            # Update collection using storage manager
+            collection_data, batch_result = self.storage_manager.update_collection(
+                collection_name, objects, if_unmodified_since
+            )
+
+            response_body = {
+                "collection": {
+                    "name": collection_data.name,
+                    "modified": collection_data.modified,
+                    "count": collection_data.count,
+                    "usage": collection_data.usage,
+                },
+                "batchResult": {
+                    "success": batch_result.success,
+                    "failed": batch_result.failed,
+                    "modified": batch_result.modified,
+                },
+            }
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except ValidationException as e:
+            return Response(
+                status_code=StatusCode.BAD_REQUEST,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except CollectionNotFoundException as e:
+            return Response(
+                status_code=StatusCode.NOT_FOUND,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except PreconditionFailedException as e:
+            return Response(
+                status_code=StatusCode.PRECONDITION_FAILED,
+                content_type="application/json",
+                body=json.dumps({"error": str(e)}),
+            )
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/info/read_collections.py
+++ b/lambda/src/routes/info/read_collections.py
@@ -1,8 +1,14 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
 
 
 class ReadCollectionsInfoRoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.get("/info/collections")
         @api.pass_event
@@ -11,12 +17,32 @@ class ReadCollectionsInfoRoute(BaseRoute):
 
     def handle(self, event):
         """Get metadata for all collections"""
-        # TODO: Implement authentication validation
-        # TODO: Implement collection metadata retrieval logic
-        # TODO: Return proper CollectionDataMap structure
+        try:
+            # Get collections using storage manager
+            collections = self.storage_manager.list_collections()
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body='{"collections": {"bookmarks": {"name": "bookmarks", "modified": 1642678800000, "count": 10, "usage": 2048}, "history": {"name": "history", "modified": 1642678900000, "count": 25, "usage": 4096}}}',
-        )
+            # Convert to map format as expected by the Smithy model
+            collections_map = {
+                collection.name: {
+                    "name": collection.name,
+                    "modified": collection.modified,
+                    "count": collection.count,
+                    "usage": collection.usage,
+                }
+                for collection in collections
+            }
+
+            response_body = {"collections": collections_map}
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/info/read_counts.py
+++ b/lambda/src/routes/info/read_counts.py
@@ -1,8 +1,14 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
 
 
 class ReadCollectionCountsRoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.get("/info/collection_counts")
         @api.pass_event
@@ -10,13 +16,25 @@ class ReadCollectionCountsRoute(BaseRoute):
             return self.handle(event)
 
     def handle(self, event):
-        """Get object counts for all collections"""
-        # TODO: Implement authentication validation
-        # TODO: Implement collection counts retrieval logic
-        # TODO: Return proper CollectionCounts map structure
+        """Get count information for all collections"""
+        try:
+            # Get collections using storage manager
+            collections = self.storage_manager.list_collections()
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body='{"counts": {"bookmarks": 10, "history": 25, "tabs": 5}}',
-        )
+            # Convert to counts format
+            counts = {collection.name: collection.count for collection in collections}
+
+            response_body = {"counts": counts}
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/info/read_quota.py
+++ b/lambda/src/routes/info/read_quota.py
@@ -1,8 +1,14 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
 
 
 class ReadQuotaInfoRoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.get("/info/quota")
         @api.pass_event
@@ -10,13 +16,36 @@ class ReadQuotaInfoRoute(BaseRoute):
             return self.handle(event)
 
     def handle(self, event):
-        """Get storage quota information"""
-        # TODO: Implement authentication validation
-        # TODO: Implement quota information retrieval logic
-        # TODO: Return proper quota structure with quota, usage, remaining
+        """Get quota information for the authenticated user"""
+        try:
+            # Get collections using storage manager to calculate current usage
+            collections = self.storage_manager.list_collections()
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body='{"quota": 104857600, "usage": 7168, "remaining": 104850432}',
-        )
+            current_collections = len(collections)
+            current_usage = sum(collection.usage for collection in collections)
+
+            # TODO: Make these configurable per user/tier
+            max_collections = 100
+            max_usage = 10485760  # 10MB
+
+            response_body = {
+                "quota": {
+                    "max_collections": max_collections,
+                    "max_usage": max_usage,
+                    "current_collections": current_collections,
+                    "current_usage": current_usage,
+                }
+            }
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/info/read_usage.py
+++ b/lambda/src/routes/info/read_usage.py
@@ -1,8 +1,14 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
+from src.services.storage_manager import StorageManager
 from src.shared.base_route import BaseRoute
 
 
 class ReadCollectionUsageRoute(BaseRoute):
+    def __init__(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def bind(self, api):
         @api.get("/info/collection_usage")
         @api.pass_event
@@ -10,13 +16,25 @@ class ReadCollectionUsageRoute(BaseRoute):
             return self.handle(event)
 
     def handle(self, event):
-        """Get storage usage for all collections"""
-        # TODO: Implement authentication validation
-        # TODO: Implement collection usage retrieval logic
-        # TODO: Return proper CollectionUsage map structure
+        """Get usage information for all collections"""
+        try:
+            # Get collections using storage manager
+            collections = self.storage_manager.list_collections()
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body='{"usage": {"bookmarks": 2048, "history": 4096, "tabs": 1024}}',
-        )
+            # Convert to usage format
+            usage = {collection.name: collection.usage for collection in collections}
+
+            response_body = {"usage": usage}
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps(response_body),
+            )
+
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/routes/storage/delete_all.py
+++ b/lambda/src/routes/storage/delete_all.py
@@ -1,8 +1,12 @@
+import json
+
 from aws_lambda_proxy import Response, StatusCode
 from src.shared.base_route import BaseRoute
+from src.shared.models import get_current_timestamp
 
 
 class DeleteAllStorageRoute(BaseRoute):
+
     def bind(self, api):
         @api.delete("/storage")
         @api.pass_event
@@ -11,12 +15,22 @@ class DeleteAllStorageRoute(BaseRoute):
 
     def handle(self, event):
         """Delete all storage data for the authenticated user"""
-        # TODO: Implement authentication validation
-        # TODO: Implement storage deletion logic
-        # TODO: Return proper timestamp in response
+        try:
+            # TODO: Implement authentication validation
+            # TODO: Implement deletion of all collections for authenticated user
 
-        return Response(
-            status_code=StatusCode.OK,
-            content_type="application/json",
-            body='{"modified": 1642678800000}',
-        )
+            # For now, return a placeholder response
+            timestamp = get_current_timestamp()
+
+            return Response(
+                status_code=StatusCode.OK,
+                content_type="application/json",
+                body=json.dumps({"modified": timestamp}),
+            )
+
+        except Exception as e:
+            return Response(
+                status_code=StatusCode.INTERNAL_SERVER_ERROR,
+                content_type="application/json",
+                body=json.dumps({"error": "Internal server error"}),
+            )

--- a/lambda/src/shared/base_route.py
+++ b/lambda/src/shared/base_route.py
@@ -10,5 +10,6 @@ class BaseRoute(ABC):
         pass
 
     @abstractmethod
-    def handle(self, event, context):
+    def handle(self, event):
+        """Handle the route request"""
         pass

--- a/lambda/src/shared/exceptions.py
+++ b/lambda/src/shared/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 from aws_lambda_proxy import Response, StatusCode
 
 
@@ -51,16 +49,6 @@ class PreconditionFailedException(SyncStorageException):
         super().__init__(message)
 
 
-class RequestTooLargeException(SyncStorageException):
-    """Request too large exception"""
-
-    status_code = StatusCode.REQUEST_TOO_LARGE
-    error_code = "RequestTooLargeException"
-
-    def __init__(self, message: str = "Request entity too large"):
-        super().__init__(message)
-
-
 class QuotaExceededException(SyncStorageException):
     """Quota exceeded exception"""
 
@@ -78,6 +66,16 @@ class CollectionNotFoundException(SyncStorageException):
     error_code = "CollectionNotFoundException"
 
     def __init__(self, message: str = "Collection not found"):
+        super().__init__(message)
+
+
+class StorageObjectNotFoundException(SyncStorageException):
+    """Storage object not found exception"""
+
+    status_code = StatusCode.NOT_FOUND
+    error_code = "StorageObjectNotFoundException"
+
+    def __init__(self, message: str = "Storage object not found"):
         super().__init__(message)
 
 

--- a/lib/stacks/service.ts
+++ b/lib/stacks/service.ts
@@ -3,7 +3,7 @@ import {Construct} from "constructs";
 import {readFileSync} from "fs";
 import * as path from "path";
 
-import {Duration, Stack, StackProps} from "aws-cdk-lib";
+import {Duration, RemovalPolicy, Stack, StackProps} from "aws-cdk-lib";
 import {
     ApiDefinition,
     EndpointType,
@@ -12,6 +12,7 @@ import {
     SpecRestApi,
 } from "aws-cdk-lib/aws-apigateway";
 import {Certificate, CertificateValidation} from "aws-cdk-lib/aws-certificatemanager";
+import {AttributeType, BillingMode, Table, TableEncryption} from "aws-cdk-lib/aws-dynamodb";
 import {Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
 import {Architecture, Runtime} from "aws-cdk-lib/aws-lambda";
 import {ARecord, HostedZone, RecordTarget} from "aws-cdk-lib/aws-route53";
@@ -25,18 +26,42 @@ export interface ServiceStackProps extends StackProps {
 
 export class ServiceStack extends Stack {
     private readonly props: ServiceStackProps;
-    private readonly apiRole: Role;
-
+    private readonly storageTable: Table;
     public readonly apiHandler: PythonFunction;
+    private readonly apiRole: Role;
     public readonly api: SpecRestApi;
 
     constructor(scope: Construct, id: string, props: ServiceStackProps) {
         super(scope, id, props);
 
         this.props = props;
+        this.storageTable = this.buildStorageTable();
         this.apiRole = this.buildApiRole();
         this.apiHandler = this.buildApiHandler();
         this.api = this.buildApi();
+    }
+
+    private buildStorageTable(): Table {
+        return new Table(this, "StorageTable", {
+            tableName: `ffsync-storage-${this.props.stageType.toLowerCase()}`,
+            encryption: TableEncryption.AWS_MANAGED,
+            partitionKey: {
+                name: "PK",
+                type: AttributeType.STRING,
+            },
+            sortKey: {
+                name: "SK",
+                type: AttributeType.STRING,
+            },
+            billingMode: BillingMode.PAY_PER_REQUEST,
+            pointInTimeRecoverySpecification: {
+                pointInTimeRecoveryEnabled: true,
+            },
+            removalPolicy:
+                this.props.stageType === StageType.PROD
+                    ? RemovalPolicy.RETAIN
+                    : RemovalPolicy.DESTROY,
+        });
     }
 
     private buildApiHandler(): PythonFunction {
@@ -48,11 +73,18 @@ export class ServiceStack extends Stack {
             handler: "lambda_handler",
             functionName: `ffsync-storage-${this.props.stageType.toLowerCase()}`,
             timeout: Duration.seconds(29),
+            memorySize: 512,
             environment: {
                 STAGE: this.props.stageType.toLowerCase(),
+                STORAGE_TABLE_NAME: this.storageTable.tableName,
             },
         });
+
+        // Grant DynamoDB permissions to Lambda
+        this.storageTable.grantReadWriteData(fn);
         fn.grantInvoke(this.apiRole);
+        this.exportValue(fn.functionName);
+
         return fn;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,7 +2420,6 @@
                 "mime-types"
             ],
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-cdk/asset-awscli-v1": "2.2.242",
                 "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
@@ -2856,6 +2855,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
@@ -2872,6 +2872,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -3820,6 +3821,7 @@
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
             "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -3945,6 +3947,7 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/graphemer": {
@@ -4007,6 +4010,7 @@
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -4950,6 +4954,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
             "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -5114,6 +5119,7 @@
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -5672,6 +5678,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -5748,6 +5755,7 @@
             "version": "7.7.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -6406,6 +6414,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
@@ -6689,6 +6698,7 @@
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">= 6"

--- a/smithy/models/bso.smithy
+++ b/smithy/models/bso.smithy
@@ -156,3 +156,7 @@ structure DeleteBasicStorageObjectOutput {
 list BasicStorageObjectList {
     member: BasicStorageObject
 }
+
+list BasicStorageObjectInputList {
+    member: BasicStorageObjectInput
+}

--- a/smithy/models/collection.smithy
+++ b/smithy/models/collection.smithy
@@ -48,8 +48,11 @@ structure CreateCollectionInput {
     @required
     collectionName: CollectionName
 
-    @required
-    objects: BasicStorageObjectList
+    @httpPayload
+    objects: BasicStorageObjectInputList
+
+    @httpHeader("X-If-Unmodified-Since")
+    ifUnmodifiedSince: Timestamp
 }
 
 @output
@@ -61,9 +64,8 @@ structure CreateCollectionOutput {
     batchResult: BatchResult
 }
 
-@idempotent
 @http(method: "POST", uri: "/storage/{collectionName}")
-@documentation("Create a new collection")
+@documentation("Create a new collection or batch create/update objects")
 operation CreateCollection {
     input: CreateCollectionInput
     output: CreateCollectionOutput
@@ -81,20 +83,57 @@ structure GetCollectionInput {
     @httpLabel
     @required
     collectionName: CollectionName
+
+    @httpQuery("ids")
+    @documentation("Comma-separated list of object IDs to retrieve")
+    ids: String
+
+    @httpQuery("newer")
+    @documentation("Return objects newer than this timestamp")
+    newer: Timestamp
+
+    @httpQuery("older")
+    @documentation("Return objects older than this timestamp")
+    older: Timestamp
+
+    @httpQuery("sort")
+    @documentation("Sort order: newest, oldest, or index")
+    sort: String
+
+    @httpQuery("limit")
+    @documentation("Maximum number of objects to return")
+    limit: Integer
+
+    @httpQuery("offset")
+    @documentation("Number of objects to skip")
+    offset: Integer
+
+    @httpQuery("full")
+    @documentation("Return full objects (1) or just IDs (0)")
+    full: Boolean
 }
 
 @output
 structure GetCollectionOutput {
-    @documentation("Collection data")
+    @documentation("Collection data (when retrieving metadata only)")
     collection: CollectionData
+
+    @documentation("List of storage objects (when retrieving objects)")
+    objects: BasicStorageObjectList
 
     @httpHeader("X-Last-Modified")
     lastModified: Timestamp
+
+    @documentation("More items available (for pagination)")
+    more: Boolean
+
+    @documentation("Next offset for pagination")
+    next_offset: Integer
 }
 
 @readonly
 @http(method: "GET", uri: "/storage/{collectionName}")
-@documentation("Get collection metadata")
+@documentation("Get collection metadata or retrieve objects with filtering")
 operation GetCollection {
     input: GetCollectionInput
     output: GetCollectionOutput
@@ -111,8 +150,9 @@ structure UpdateCollectionInput {
     @required
     collectionName: CollectionName
 
+    @httpPayload
     @required
-    objects: BasicStorageObjectList
+    objects: BasicStorageObjectInputList
 
     @httpHeader("X-If-Unmodified-Since")
     ifUnmodifiedSince: Timestamp

--- a/smithy/models/storage.smithy
+++ b/smithy/models/storage.smithy
@@ -20,6 +20,7 @@ resource StorageInfo {
         CollectionCountsResource
         CollectionUsageResource
         QuotaInfo
+        ConfigurationInfo
     ]
     read: GetStorageInfo
 }
@@ -32,6 +33,9 @@ resource CollectionUsageResource { read: GetCollectionUsage }
 
 @documentation("Storage quota information")
 resource QuotaInfo { read: GetQuotaInfo }
+
+@documentation("Server configuration information")
+resource ConfigurationInfo { read: GetConfigurationInfo }
 
 @idempotent
 @http(method: "DELETE", uri: "/storage")
@@ -83,6 +87,17 @@ operation GetCollectionUsage {
 operation GetQuotaInfo {
     input: GetQuotaInfoInput
     output: GetQuotaInfoOutput
+    errors: [
+        AuthenticationException
+    ]
+}
+
+@readonly
+@http(method: "GET", uri: "/info/configuration")
+@documentation("Get server configuration limits")
+operation GetConfigurationInfo {
+    input: GetConfigurationInfoInput
+    output: GetConfigurationInfoOutput
     errors: [
         AuthenticationException
     ]
@@ -175,4 +190,23 @@ structure GetQuotaInfoOutput {
 
     @documentation("Remaining storage in bytes")
     remaining: Long
+}
+
+structure GetConfigurationInfoInput {}
+
+structure GetConfigurationInfoOutput {
+    @documentation("Maximum number of records per POST request")
+    max_post_records: Integer
+
+    @documentation("Maximum size of POST request body in bytes")
+    max_post_bytes: Long
+
+    @documentation("Maximum size of individual record in bytes")
+    max_record_payload_bytes: Long
+
+    @documentation("Maximum total size of all records in a collection")
+    max_total_records: Long
+
+    @documentation("Maximum total size of all records in bytes")
+    max_total_bytes: Long
 }


### PR DESCRIPTION
- Add DynamoDB storage table with PK/SK schema
- Implement BSO (Basic Storage Object) CRUD operations
- Implement collection management endpoints
- Add info endpoints for collections, counts, quota, and usage
- Add storage deletion endpoint
- Add monitoring dashboard configuration
- Update service stack with storage table and IAM permissions