### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lambda-tests.yml
+++ b/.github/workflows/lambda-tests.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/layertwo/ffsync/security/code-scanning/1](https://github.com/layertwo/ffsync/security/code-scanning/1)

The best way to fix this issue is to add an explicit `permissions` block specifying the least privilege necessary at the job or workflow level. Since the "test" job does not need to write to the repository or pull requests (its only interactions with GitHub are checking out code and uploading artifacts), it suffices to grant it `contents: read` permission explicitly. This can be done by adding:

```yaml
permissions:
  contents: read
```

immediately under line 14 (the `test:` key), and indented to match the job definition structure. No modifications to dependencies or other files are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
