### PR TITLE
feat: add FrontendStack for CloudFront deployment

### DIFF
--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -46,6 +46,10 @@ jobs:
         working-directory: smithy
         run: ./gradlew smithyBuild
 
+      - name: Build frontend
+        working-directory: frontend
+        run: npm ci && npm run build
+
       - name: Build TypeScript
         run: npm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,10 @@ jobs:
         working-directory: smithy
         run: ./gradlew smithyBuild
 
+      - name: Build frontend
+        working-directory: frontend
+        run: npm ci && npm run build
+
       - name: Build TypeScript
         run: npm run build
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,12 @@
+import type {Config} from "jest";
+
+const config: Config = {
+    testEnvironment: "node",
+    roots: ["<rootDir>/test"],
+    testMatch: ["**/*.test.ts"],
+    transform: {
+        "^.+\\.tsx?$": "ts-jest",
+    },
+};
+
+export default config;

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -2,6 +2,7 @@
 import {App} from "aws-cdk-lib";
 
 import {ACCOUNT_ID, REGION, StageType} from "./config";
+import {FrontendStack} from "./stacks/frontend";
 import {GitHubOidcStack} from "./stacks/github-oidc";
 import {MonitoringStack} from "./stacks/monitoring";
 import {ServiceStack} from "./stacks/service";
@@ -28,6 +29,11 @@ new GitHubOidcStack(app, "GitHubOidcStack", {
         storageApi: serviceStack.storageApi,
         storageHandler: serviceStack.storageHandler,
         storageTable: serviceStack.storageTable,
+    });
+
+    new FrontendStack(app, `Frontend-${stageType.toLowerCase()}`, {
+        env,
+        stageType,
     });
 });
 

--- a/lib/stacks/frontend.ts
+++ b/lib/stacks/frontend.ts
@@ -1,0 +1,116 @@
+import {Construct} from "constructs";
+import * as path from "path";
+
+import {Duration, RemovalPolicy, Stack, StackProps} from "aws-cdk-lib";
+import {Certificate, DnsValidatedCertificate} from "aws-cdk-lib/aws-certificatemanager";
+import {
+    Distribution,
+    PriceClass,
+    SecurityPolicyProtocol,
+    ViewerProtocolPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+import {S3BucketOrigin} from "aws-cdk-lib/aws-cloudfront-origins";
+import {HostedZone, IHostedZone, RecordSet, RecordTarget, RecordType} from "aws-cdk-lib/aws-route53";
+import {CloudFrontTarget} from "aws-cdk-lib/aws-route53-targets";
+import {BlockPublicAccess, Bucket} from "aws-cdk-lib/aws-s3";
+import {BucketDeployment, Source} from "aws-cdk-lib/aws-s3-deployment";
+
+import {BASE_DOMAIN, HOSTED_ZONE_ID, StageType} from "../config";
+
+export interface FrontendStackProps extends StackProps {
+    stageType: StageType;
+}
+
+export class FrontendStack extends Stack {
+    private readonly props: FrontendStackProps;
+
+    private readonly hostedZone: IHostedZone;
+    private readonly bucket: Bucket;
+    private readonly certificate: Certificate;
+    public readonly distribution: Distribution;
+
+    private get endpoint(): string {
+        return `${this.props.stageType.toLowerCase()}.${BASE_DOMAIN}`;
+    }
+
+    constructor(scope: Construct, id: string, props: FrontendStackProps) {
+        super(scope, id, props);
+        this.props = props;
+
+        this.hostedZone = HostedZone.fromHostedZoneAttributes(this, "HostedZone", {
+            hostedZoneId: HOSTED_ZONE_ID,
+            zoneName: BASE_DOMAIN,
+        });
+        this.bucket = this.buildBucket()
+        this.certificate = this.buildCertificate();
+
+        this.distribution = this.buildDistribution();
+    }
+
+    private buildBucket(): Bucket {
+        return new Bucket(this, "FrontendBucket", {
+            bucketName: `ffsync-frontend-${this.props.stageType.toLowerCase()}`,
+            blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+            versioned: true,
+            removalPolicy: RemovalPolicy.DESTROY,
+            autoDeleteObjects: true,
+        });
+    }
+
+    private buildCertificate(): Certificate {
+        // DnsValidatedCertificate is deprecated but required here for cross-region
+        // certificate creation in a single stack. CloudFront requires us-east-1.
+        // TODO: Migrate to a separate us-east-1 certificate stack when upgrading CDK.
+        return new DnsValidatedCertificate(this, "Certificate", {
+            domainName: this.endpoint,
+            hostedZone: this.hostedZone,
+            region: "us-east-1",
+        });
+    }
+
+    private buildDistribution(): Distribution {
+        const distribution = new Distribution(this, "Distribution", {
+            defaultBehavior: {
+                origin: S3BucketOrigin.withOriginAccessControl(this.bucket),
+                viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            },
+            domainNames: [BASE_DOMAIN],
+            certificate: this.certificate,
+            defaultRootObject: "index.html",
+            minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2021,
+            priceClass: PriceClass.PRICE_CLASS_100,
+            errorResponses: [
+                {
+                    httpStatus: 403,
+                    responseHttpStatus: 200,
+                    responsePagePath: "/index.html",
+                    ttl: Duration.seconds(0),
+                },
+                {
+                    httpStatus: 404,
+                    responseHttpStatus: 200,
+                    responsePagePath: "/index.html",
+                    ttl: Duration.seconds(0),
+                },
+            ],
+        });
+
+
+        [RecordType.A, RecordType.AAAA].map((recordType) => {
+            new RecordSet(this, `${recordType}RecordSet`, {
+                recordType,
+                zone: this.hostedZone,
+                recordName: this.endpoint,
+                target: RecordTarget.fromAlias(new CloudFrontTarget(distribution)),
+            });
+        });
+
+        new BucketDeployment(this, "DeployFrontend", {
+            sources: [Source.asset(path.join(__dirname, "../../frontend/dist"))],
+            destinationBucket: this.bucket,
+            distribution,
+            distributionPaths: ["/*"],
+        });
+        return distribution;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,17 +1708,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
-            "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+            "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.56.0",
-                "@typescript-eslint/type-utils": "8.56.0",
-                "@typescript-eslint/utils": "8.56.0",
-                "@typescript-eslint/visitor-keys": "8.56.0",
+                "@typescript-eslint/scope-manager": "8.56.1",
+                "@typescript-eslint/type-utils": "8.56.1",
+                "@typescript-eslint/utils": "8.56.1",
+                "@typescript-eslint/visitor-keys": "8.56.1",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.4.0"
@@ -1731,22 +1731,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.56.0",
+                "@typescript-eslint/parser": "^8.56.1",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
-            "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+            "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.56.0",
-                "@typescript-eslint/types": "8.56.0",
-                "@typescript-eslint/typescript-estree": "8.56.0",
-                "@typescript-eslint/visitor-keys": "8.56.0",
+                "@typescript-eslint/scope-manager": "8.56.1",
+                "@typescript-eslint/types": "8.56.1",
+                "@typescript-eslint/typescript-estree": "8.56.1",
+                "@typescript-eslint/visitor-keys": "8.56.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1762,14 +1762,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
-            "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+            "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.56.0",
-                "@typescript-eslint/types": "^8.56.0",
+                "@typescript-eslint/tsconfig-utils": "^8.56.1",
+                "@typescript-eslint/types": "^8.56.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1784,14 +1784,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
-            "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+            "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.0",
-                "@typescript-eslint/visitor-keys": "8.56.0"
+                "@typescript-eslint/types": "8.56.1",
+                "@typescript-eslint/visitor-keys": "8.56.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1802,9 +1802,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
-            "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+            "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1819,15 +1819,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
-            "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+            "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.0",
-                "@typescript-eslint/typescript-estree": "8.56.0",
-                "@typescript-eslint/utils": "8.56.0",
+                "@typescript-eslint/types": "8.56.1",
+                "@typescript-eslint/typescript-estree": "8.56.1",
+                "@typescript-eslint/utils": "8.56.1",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.4.0"
             },
@@ -1844,9 +1844,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
-            "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+            "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1858,18 +1858,18 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
-            "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+            "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.56.0",
-                "@typescript-eslint/tsconfig-utils": "8.56.0",
-                "@typescript-eslint/types": "8.56.0",
-                "@typescript-eslint/visitor-keys": "8.56.0",
+                "@typescript-eslint/project-service": "8.56.1",
+                "@typescript-eslint/tsconfig-utils": "8.56.1",
+                "@typescript-eslint/types": "8.56.1",
+                "@typescript-eslint/visitor-keys": "8.56.1",
                 "debug": "^4.4.3",
-                "minimatch": "^9.0.5",
+                "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
                 "ts-api-utils": "^2.4.0"
@@ -1885,17 +1885,56 @@
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+            "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+            "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
-            "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+            "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.56.0",
-                "@typescript-eslint/types": "8.56.0",
-                "@typescript-eslint/typescript-estree": "8.56.0"
+                "@typescript-eslint/scope-manager": "8.56.1",
+                "@typescript-eslint/types": "8.56.1",
+                "@typescript-eslint/typescript-estree": "8.56.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1910,13 +1949,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
-            "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+            "version": "8.56.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+            "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.0",
+                "@typescript-eslint/types": "8.56.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1928,9 +1967,9 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-            "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2253,9 +2292,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2358,9 +2397,9 @@
             }
         },
         "node_modules/aws-cdk-lib": {
-            "version": "2.239.0",
-            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.239.0.tgz",
-            "integrity": "sha512-0qpYrE4HL6yRaQriRukfX7m82vNj3otce6v4Y5qK859ILdZBCaz/wqqYgdTnFh6LcA11GAg/Y8l8a+j/VtczyA==",
+            "version": "2.240.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.240.0.tgz",
+            "integrity": "sha512-3dXmUnPB5kK0VgrNHOlV3jiQM4Dungukk/CV91nclO2lgNcrGyigauJdzmz9sOmI1gbKJJ2SRAotaXityzZMRw==",
             "bundleDependencies": [
                 "@balena/dockerignore",
                 "@aws-cdk/cloud-assembly-api",
@@ -2387,7 +2426,7 @@
                 "ignore": "^5.3.2",
                 "jsonschema": "^1.5.0",
                 "mime-types": "^2.1.35",
-                "minimatch": "^3.1.2",
+                "minimatch": "^10.2.1",
                 "punycode": "^2.3.1",
                 "semver": "^7.7.4",
                 "table": "^6.9.0",
@@ -2489,17 +2528,22 @@
             }
         },
         "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-            "version": "1.0.2",
+            "version": "4.0.4",
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-            "version": "1.1.12",
+            "version": "5.0.3",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/aws-cdk-lib/node_modules/case": {
@@ -2523,11 +2567,6 @@
         },
         "node_modules/aws-cdk-lib/node_modules/color-name": {
             "version": "1.1.4",
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/aws-cdk-lib/node_modules/concat-map": {
-            "version": "0.0.1",
             "inBundle": true,
             "license": "MIT"
         },
@@ -2639,14 +2678,17 @@
             }
         },
         "node_modules/aws-cdk-lib/node_modules/minimatch": {
-            "version": "3.1.2",
+            "version": "10.2.2",
             "inBundle": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^5.0.2"
             },
             "engines": {
-                "node": "*"
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/aws-cdk-lib/node_modules/punycode": {
@@ -5621,9 +5663,9 @@
             }
         },
         "node_modules/prettier-package-json/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+            "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6125,9 +6167,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+            "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {

--- a/test/frontend.test.ts
+++ b/test/frontend.test.ts
@@ -1,0 +1,63 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import {App} from "aws-cdk-lib";
+import {Template} from "aws-cdk-lib/assertions";
+
+import {StageType} from "../lib/config";
+import {FrontendStack} from "../lib/stacks/frontend";
+
+const distDir = path.join(__dirname, "../frontend/dist");
+
+beforeAll(() => {
+    // Source.asset requires the directory to exist with at least one file.
+    fs.mkdirSync(distDir, {recursive: true});
+    fs.writeFileSync(path.join(distDir, "index.html"), "<html></html>");
+});
+
+afterAll(() => {
+    fs.rmSync(distDir, {recursive: true, force: true});
+});
+
+describe("FrontendStack", () => {
+    test("synthesizes expected resources", () => {
+        const app = new App();
+        const stack = new FrontendStack(app, "TestFrontend", {
+            env: {account: "123456789012", region: "us-west-2"},
+            stageType: StageType.PROD,
+        });
+
+        const template = Template.fromStack(stack);
+
+        template.resourceCountIs("AWS::S3::Bucket", 1);
+        template.resourceCountIs("AWS::CloudFront::Distribution", 1);
+        template.resourceCountIs("AWS::Route53::RecordSet", 2);
+
+        template.hasResourceProperties("AWS::S3::Bucket", {
+            BucketName: "ffsync-frontend-prod",
+            PublicAccessBlockConfiguration: {
+                BlockPublicAcls: true,
+                BlockPublicPolicy: true,
+                IgnorePublicAcls: true,
+                RestrictPublicBuckets: true,
+            },
+            VersioningConfiguration: {
+                Status: "Enabled",
+            },
+        });
+
+        template.hasResourceProperties("AWS::CloudFront::Distribution", {
+            DistributionConfig: {
+                DefaultRootObject: "index.html",
+                PriceClass: "PriceClass_100",
+            },
+        });
+
+        // DnsValidatedCertificate creates a custom resource instead of a native
+        // AWS::CertificateManager::Certificate resource.
+        template.hasResourceProperties("AWS::CloudFormation::CustomResource", {
+            DomainName: "ffsync.layertwo.dev",
+            Region: "us-east-1",
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Add new `FrontendStack` CDK stack that deploys the React/Vite frontend to CloudFront + S3
- Private S3 bucket with Origin Access Control (OAC), no public access
- CloudFront distribution with TLS 1.2, HTTPS redirect, and SPA routing (403/404 → index.html)
- Cross-region ACM certificate in us-east-1 via `DnsValidatedCertificate`
- Route53 A and AAAA alias records for `<stage>.ffsync.layertwo.dev`
- `BucketDeployment` with local bundling (npm ci + vite build) and Docker fallback
- Wired into `lib/app.ts` stage loop as `Frontend-prod`
- CDK synthesis test with mocked child_process bundling

## Test plan

- [x] CDK synthesis test passes (`npx jest --verbose`)
- [x] TypeScript compiles cleanly (`npm run build`)
- [x] Frontend-prod template synthesizes with all expected resources
- [ ] Deploy to AWS and verify CloudFront serves the frontend
- [ ] Verify SPA routing works (navigate to a deep path, refresh)
- [ ] Verify HTTPS redirect works