### PR TITLE
feat: generate frontend config.json at deploy time via SSM Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ API Gateway (REST)
             │
             ├── DynamoDB  ─ collections & BSOs (per-user partition key)
             │     └── GSI: UserCollectionsIndex (user_id → collection metadata)
-            ├── Secrets Manager ─ OIDC config / HAWK credentials
             └── CloudWatch ─ metrics & alarms (via Monitoring stack)
+
+CloudFront ─ serves frontend SPA from S3
+      │
+      └── S3 Bucket ─ frontend assets + generated config.json
 
 CDK Stacks (TypeScript / AWS CDK):
   lib/stacks/service.ts     ─ core API Gateway + Lambda + DynamoDB resources
-  lib/stacks/pipeline.ts    ─ CodePipeline CI/CD deployment
+  lib/stacks/frontend.ts    ─ CloudFront + S3 frontend deployment
   lib/stacks/monitoring.ts  ─ CloudWatch dashboard & alarms
 ```
 
@@ -49,13 +52,18 @@ cd lambda && pip install -r requirements.txt && cd ..
 cdk bootstrap aws://<ACCOUNT_ID>/<REGION>
 ```
 
-### 3. Configure the stack
+### 3. Create SSM Parameters (first time per stage)
 
-Copy and edit the config file:
+The OIDC provider URL and client ID are stored as SSM Parameters, created outside of CDK:
 
 ```bash
-cp lib/config/default.ts lib/config/local.ts
-# Edit lib/config/local.ts — set your domain, OIDC issuer URL, etc.
+aws ssm put-parameter --name /ffsync/prod/oidc-provider-url \
+  --value "https://your-oidc-provider/application/o/firefox-sync/" \
+  --type String
+
+aws ssm put-parameter --name /ffsync/prod/client-id \
+  --value "your-oauth-client-id" \
+  --type String
 ```
 
 ### 4. Synthesize and deploy
@@ -64,6 +72,8 @@ cp lib/config/default.ts lib/config/local.ts
 cdk synth    # verify the CloudFormation template renders cleanly
 cdk deploy   # deploy all stacks to your AWS account
 ```
+
+The frontend `config.json` is generated automatically at deploy time from SSM Parameters and cross-stack references.
 
 ### 5. Point Firefox at your server
 
@@ -78,7 +88,8 @@ identity.sync.tokenserver.uri = https://<your-api-domain>/token/1.0/sync/1.5
 | Variable | Description | Default |
 |---|---|---|
 | `BASE_DOMAIN` | Root domain for the API Gateway custom domain | required |
-| `OIDC_SECRET_ARN` | ARN of the Secrets Manager secret holding OIDC configuration | required |
+| `OIDC_PROVIDER_URL` | OIDC provider URL (from SSM Parameter at deploy time) | required |
+| `OIDC_CLIENT_ID` | OAuth client ID (from SSM Parameter at deploy time) | required |
 | `STORAGE_TABLE_NAME` | DynamoDB table name for BSO/collection storage | set by CDK |
 | `TOKEN_USERS_TABLE_NAME` | DynamoDB table for token-to-user mapping | set by CDK |
 | `TOKEN_CACHE_TABLE_NAME` | DynamoDB table for token caching | set by CDK |

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Runtime config (generated at deploy time, copied from .example for local dev)
+public/config.json

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,7 +1,0 @@
-{
-  "oidcProviderUrl": "https://auth.example.com/application/o/firefox-sync/",
-  "clientId": "your-client-id-here",
-  "redirectUri": "https://sync-auth.example.com",
-  "tokenServerUrl": "https://sync.example.com",
-  "scopes": ["openid", "profile", "email"]
-}

--- a/lambda/src/environment/service_provider.py
+++ b/lambda/src/environment/service_provider.py
@@ -1,4 +1,3 @@
-import json
 import os
 from functools import cached_property
 
@@ -91,8 +90,12 @@ class ServiceProvider:
     # Token API properties
 
     @cached_property
-    def oidc_secret_arn(self):
-        return os.environ.get("OIDC_SECRET_ARN")
+    def oidc_provider_url(self) -> str:
+        return os.environ["OIDC_PROVIDER_URL"]
+
+    @cached_property
+    def oidc_client_id(self) -> str:
+        return os.environ["OIDC_CLIENT_ID"]
 
     @cached_property
     def base_domain(self):
@@ -101,22 +104,6 @@ class ServiceProvider:
     @cached_property
     def storage_domain(self) -> str:
         return f"storage.{self.base_domain}"
-
-    @cached_property
-    def secretsmanager_client(self):  # pragma: nocover
-        """Create Secrets Manager client"""
-        return self.session.client("secretsmanager")
-
-    @cached_property
-    def oidc_config(self) -> dict:
-        """
-        Fetch OIDC configuration from Secrets Manager.
-
-        Returns:
-            dict with 'provider_url' and 'client_id' keys
-        """
-        response = self.secretsmanager_client.get_secret_value(SecretId=self.oidc_secret_arn)
-        return json.loads(response["SecretString"])
 
     @cached_property
     def clock_skew_tolerance(self) -> int:
@@ -149,10 +136,10 @@ class ServiceProvider:
 
     @cached_property
     def oidc_validator(self) -> OIDCValidator:
-        """Create OIDC validator with configuration from Secrets Manager"""
+        """Create OIDC validator with configuration from environment variables"""
         return OIDCValidator(
-            provider_url=self.oidc_config["provider_url"],
-            client_id=self.oidc_config["client_id"],
+            provider_url=self.oidc_provider_url,
+            client_id=self.oidc_client_id,
             clock_skew_tolerance=self.clock_skew_tolerance,
             cache_ttl_seconds=self.oidc_cache_ttl_seconds,
         )

--- a/lambda/tests/conftest.py
+++ b/lambda/tests/conftest.py
@@ -26,8 +26,13 @@ def token_users_table_name():
 
 
 @pytest.fixture
-def oidc_secret_arn():
-    return "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-oidc-config"
+def oidc_provider_url():
+    return "https://auth.example.com"
+
+
+@pytest.fixture
+def oidc_client_id():
+    return "test-client-id"
 
 
 @pytest.fixture
@@ -50,7 +55,8 @@ def setup_environment(
     storage_table_name,
     token_users_table_name,
     token_cache_table_name,
-    oidc_secret_arn,
+    oidc_provider_url,
+    oidc_client_id,
     base_domain,
 ):
     """Mock environment variables"""
@@ -61,7 +67,8 @@ def setup_environment(
     monkeypatch.setenv("STORAGE_TABLE_NAME", storage_table_name)
     monkeypatch.setenv("TOKEN_USERS_TABLE_NAME", token_users_table_name)
     monkeypatch.setenv("TOKEN_CACHE_TABLE_NAME", token_cache_table_name)
-    monkeypatch.setenv("OIDC_SECRET_ARN", oidc_secret_arn)
+    monkeypatch.setenv("OIDC_PROVIDER_URL", oidc_provider_url)
+    monkeypatch.setenv("OIDC_CLIENT_ID", oidc_client_id)
     monkeypatch.setenv("BASE_DOMAIN", base_domain)
     monkeypatch.setenv("CLOCK_SKEW_TOLERANCE", "300")
     monkeypatch.setenv("HAWK_TIMESTAMP_SKEW_TOLERANCE", "60")
@@ -69,37 +76,9 @@ def setup_environment(
     monkeypatch.setenv("TOKEN_DURATION", "300")
 
 
-class MockServiceProvider(ServiceProvider):
-    def __init__(self, boto_session):
-        """
-        Args:
-            boto_session: The test boto3.Session
-        """
-        self._mock_session = boto_session
-
-    @property
-    def session(self):
-        """Override to return test session"""
-        return self._mock_session
-
-
 @pytest.fixture
 def mock_service_provider(boto_session):
-    """
-    Fixture providing MockServiceProvider with stubbed AWS clients.
-
-    The secretsmanager_client is injected into the provider's __dict__,
-    bypassing the @cached_property so the stubbed client is used.
-
-    Usage:
-        def test_integration(mock_service_provider, secretsmanager_stubber):
-            # Add stubbed Secrets Manager responses
-            secretsmanager_stubber.add_response('get_secret_value', {...})
-
-            # Pass directly to lambda handler
-            result = lambda_handler(event, context, service_provider=mock_service_provider)
-    """
-    return MockServiceProvider(boto_session)
+    return ServiceProvider()
 
 
 @pytest.fixture

--- a/lambda/tests/entrypoint/test_token_api.py
+++ b/lambda/tests/entrypoint/test_token_api.py
@@ -28,19 +28,8 @@ def token_request_event():
 class TestTokenApiAuthErrors:
     """Tests for authentication error handling - these don't need OIDC validation"""
 
-    def test_missing_auth_header_returns_401(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn, sample_lambda_context
-    ):
+    def test_missing_auth_header_returns_401(self, mock_service_provider, sample_lambda_context):
         """Test request without Authorization header returns 401"""
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
         event = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",
@@ -52,19 +41,8 @@ class TestTokenApiAuthErrors:
         result = token_api_handler(event, sample_lambda_context, mock_service_provider)
         assert result["statusCode"] == 401
 
-    def test_missing_auth_header_error_format(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn, sample_lambda_context
-    ):
+    def test_missing_auth_header_error_format(self, mock_service_provider, sample_lambda_context):
         """Test missing auth header returns proper error format"""
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
         event = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",
@@ -80,19 +58,8 @@ class TestTokenApiAuthErrors:
         assert body["errors"][0]["name"] == "Authorization"
         assert body["errors"][0]["location"] == "header"
 
-    def test_malformed_auth_header_returns_400(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn, sample_lambda_context
-    ):
+    def test_malformed_auth_header_returns_400(self, mock_service_provider, sample_lambda_context):
         """Test request with malformed Authorization header returns 400"""
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
         event = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",
@@ -104,19 +71,8 @@ class TestTokenApiAuthErrors:
         result = token_api_handler(event, sample_lambda_context, mock_service_provider)
         assert result["statusCode"] == 400
 
-    def test_malformed_auth_header_error_format(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn, sample_lambda_context
-    ):
+    def test_malformed_auth_header_error_format(self, mock_service_provider, sample_lambda_context):
         """Test malformed auth header returns proper error format"""
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
         event = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",
@@ -133,19 +89,8 @@ class TestTokenApiAuthErrors:
 class TestTokenApiValidationErrors:
     """Tests for request validation error handling"""
 
-    def test_invalid_content_type_returns_415(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn, sample_lambda_context
-    ):
+    def test_invalid_content_type_returns_415(self, mock_service_provider, sample_lambda_context):
         """Test request with invalid Content-Type returns 415"""
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
         event = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",
@@ -160,19 +105,8 @@ class TestTokenApiValidationErrors:
         result = token_api_handler(event, sample_lambda_context, mock_service_provider)
         assert result["statusCode"] == 415
 
-    def test_invalid_content_type_error_format(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn, sample_lambda_context
-    ):
+    def test_invalid_content_type_error_format(self, mock_service_provider, sample_lambda_context):
         """Test invalid content type returns proper error format"""
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
         event = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",
@@ -192,58 +126,16 @@ class TestTokenApiValidationErrors:
 class TestServiceProviderTokenApiProperties:
     """Tests for ServiceProvider token API property initialization"""
 
-    def test_oidc_config_fetches_from_secrets_manager(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn
-    ):
-        """Test oidc_config fetches and parses secret from Secrets Manager"""
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
-        config = mock_service_provider.oidc_config
-
-        assert config["provider_url"] == "https://auth.example.com"
-        assert config["client_id"] == "test-client-id"
-
-    def test_oidc_validator_uses_oidc_config(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn
-    ):
-        """Test oidc_validator is initialized with config from Secrets Manager"""
-
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
+    def test_oidc_validator_uses_env_vars(self, mock_service_provider):
+        """Test oidc_validator is initialized with config from env vars"""
         validator = mock_service_provider.oidc_validator
 
         assert isinstance(validator, OIDCValidator)
         assert validator.provider_url == "https://auth.example.com"
         assert validator.client_id == "test-client-id"
 
-    def test_token_api_router_creates_router_with_request_route(
-        self, mock_service_provider, secretsmanager_stubber, oidc_secret_arn
-    ):
+    def test_token_api_router_creates_router_with_request_route(self, mock_service_provider):
         """Test token_api_router creates ApiRouter with RequestTokenRoute"""
-
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {
-                "SecretString": json.dumps(
-                    {"provider_url": "https://auth.example.com", "client_id": "test-client-id"}
-                )
-            },
-            {"SecretId": oidc_secret_arn},
-        )
         router = mock_service_provider.token_api_router
 
         assert isinstance(router, ApiRouter)

--- a/lambda/tests/fixtures/boto.py
+++ b/lambda/tests/fixtures/boto.py
@@ -82,34 +82,6 @@ def dynamodb_table(boto_session, dynamodb_stubber, storage_table_name):
     return table
 
 
-@pytest.fixture
-def secretsmanager_client(boto_session):
-    """
-    Provides a Secrets Manager client for stubbing.
-
-    This client is created once and can be stubbed, then injected
-    into the ServiceProvider via MockServiceProvider.
-    """
-    return boto_session.client("secretsmanager")
-
-
-@pytest.fixture
-def secretsmanager_stubber(secretsmanager_client):
-    """
-    Provides a Secrets Manager client with botocore Stubber for testing.
-
-    Usage:
-        def test_secrets(secretsmanager_stubber):
-            secretsmanager_stubber.add_response(
-                'get_secret_value',
-                {'SecretString': '{"key": "value"}'},
-                {'SecretId': 'my-secret-arn'}
-            )
-    """
-    with Stubber(secretsmanager_client) as stubber:
-        yield stubber
-
-
 @pytest.fixture(autouse=True)
 def boto_session(aws_region_name, aws_access_key_id, aws_secret_access_key, aws_session_token):
     # Load internal service models before creating a boto session
@@ -135,13 +107,11 @@ def boto_session_patch(boto_session):
 
 @pytest.fixture(autouse=True)
 def boto_resource_patch(
-    boto_session, boto_session_patch, dynamodb_client, dynamodb_resource, secretsmanager_client
+    boto_session, boto_session_patch, dynamodb_client, dynamodb_resource
 ) -> Generator:
     def client(service, *args, **kwargs):
         if service == "dynamodb":
             return dynamodb_client
-        if service == "secretsmanager":
-            return secretsmanager_client
 
         raise ValueError(f"client for {service} not recognized")
 

--- a/lambda/tests/integration/test_token_server_mozilla_spec.py
+++ b/lambda/tests/integration/test_token_server_mozilla_spec.py
@@ -27,7 +27,6 @@ class TestGetMethodTokenIssuance:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -42,16 +41,6 @@ class TestGetMethodTokenIssuance:
 
         **Validates: Requirement 1.1**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         # Mock OIDC token validation
         user_id = "test-user-get-method"
         client_state = "test-client-state-123"
@@ -149,7 +138,6 @@ class TestGetMethodTokenIssuance:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -157,16 +145,6 @@ class TestGetMethodTokenIssuance:
 
         **Validates: Requirement 1.1**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         user_id = "test-user-spec"
         mock_oidc_token = "mock.oidc.token"
 
@@ -238,7 +216,6 @@ class TestClientStateHistory:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -252,16 +229,6 @@ class TestClientStateHistory:
 
         **Validates: Requirements 13.2, 13.8**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         user_id = "test-user-state-change"
         mock_oidc_token = "mock.oidc.token"
 
@@ -321,11 +288,6 @@ class TestClientStateHistory:
             uid_1 = body_1["uid"]
 
         # Second request with client_state "state2" (different)
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         token_event_2 = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",
@@ -416,7 +378,6 @@ class TestClientStateHistory:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -429,16 +390,6 @@ class TestClientStateHistory:
 
         **Validates: Requirement 13.6**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         user_id = "test-user-reused-state"
         mock_oidc_token = "mock.oidc.token"
 
@@ -513,7 +464,6 @@ class TestClientStateHistory:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -526,16 +476,6 @@ class TestClientStateHistory:
 
         **Validates: Requirement 13.7**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         user_id = "test-user-empty-state"
         mock_oidc_token = "mock.oidc.token"
 
@@ -614,7 +554,6 @@ class TestNewErrorStatuses:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -626,16 +565,6 @@ class TestNewErrorStatuses:
 
         **Validates: Requirement 6.6, 18.2**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         mock_oidc_token = "mock.oidc.token"
 
         token_event = {
@@ -670,7 +599,6 @@ class TestNewErrorStatuses:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -694,7 +622,6 @@ class TestNewErrorStatuses:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -715,7 +642,6 @@ class TestNewErrorStatuses:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
         monkeypatch,
     ):
@@ -731,16 +657,6 @@ class TestNewErrorStatuses:
         """
         # Set environment variable to disable new users
         monkeypatch.setenv("NEW_USERS_ENABLED", "false")
-
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
 
         user_id = "test-user-new-disabled"
         mock_oidc_token = "mock.oidc.token"
@@ -796,7 +712,6 @@ class TestResponseHeaders:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -804,16 +719,6 @@ class TestResponseHeaders:
 
         **Validates: Requirement 14.1**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         user_id = "test-user-timestamp-200"
         mock_oidc_token = "mock.oidc.token"
 
@@ -888,7 +793,6 @@ class TestResponseHeaders:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -896,16 +800,6 @@ class TestResponseHeaders:
 
         **Validates: Requirement 14.2**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         # Request without Authorization header (triggers 401)
         token_event = {
             "httpMethod": "GET",
@@ -937,7 +831,6 @@ class TestResponseHeaders:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -945,16 +838,6 @@ class TestResponseHeaders:
 
         **Validates: Requirement 16.1**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         # Request without Authorization header (triggers 401)
         token_event = {
             "httpMethod": "GET",
@@ -984,7 +867,6 @@ class TestResponseHeaders:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -992,16 +874,6 @@ class TestResponseHeaders:
 
         **Validates: Requirements 14.2, 16.1**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         # Request without Authorization header
         token_event = {
             "httpMethod": "GET",
@@ -1032,7 +904,6 @@ class TestNodeReset:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -1045,16 +916,6 @@ class TestNodeReset:
 
         **Validates: Requirement 2.4**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         user_id = "test-user-node-reset"
         mock_oidc_token = "mock.oidc.token"
 
@@ -1115,11 +976,6 @@ class TestNodeReset:
             api_endpoint_1 = body_1["api_endpoint"]
 
         # Second request with client_state "state2"
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         token_event_2 = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",
@@ -1214,7 +1070,6 @@ class TestNodeReset:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -1222,16 +1077,6 @@ class TestNodeReset:
 
         **Validates: Requirement 2.4**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         user_id = "test-user-endpoint-reset"
         mock_oidc_token = "mock.oidc.token"
 
@@ -1293,11 +1138,6 @@ class TestNodeReset:
             assert "/1.5/" in api_endpoint_1
 
         # Second request with different client state
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         token_event_2 = {
             "httpMethod": "GET",
             "path": "/1.0/sync/1.5",

--- a/lambda/tests/integration/test_token_to_storage_flow.py
+++ b/lambda/tests/integration/test_token_to_storage_flow.py
@@ -30,7 +30,6 @@ class TestTokenServerToStorageServerFlow:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -51,16 +50,6 @@ class TestTokenServerToStorageServerFlow:
         **Validates: Requirements 4.5, 12.1, 12.2, 12.3**
         """
         # ===== Step 1-6: Token Server Issues HAWK Credentials =====
-
-        # Mock OIDC configuration retrieval
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
 
         # Mock OIDC token validation (we'll mock the entire validation process)
         user_id = "test-user-123"
@@ -257,7 +246,6 @@ class TestTokenServerToStorageServerFlow:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """
@@ -270,16 +258,6 @@ class TestTokenServerToStorageServerFlow:
 
         **Validates: Requirement 4.5**
         """
-        # Mock OIDC configuration
-        oidc_config = {
-            "provider_url": "https://auth.example.com",
-            "client_id": "test-client-id",
-        }
-        secretsmanager_stubber.add_response(
-            "get_secret_value",
-            {"SecretString": json.dumps(oidc_config)},
-        )
-
         # Mock OIDC token validation
         user_id = "test-user-456"
         mock_oidc_token = "mock.oidc.token"
@@ -410,7 +388,6 @@ class TestTokenServerToStorageServerFlow:
         self,
         mock_service_provider,
         dynamodb_stubber,
-        secretsmanager_stubber,
         sample_lambda_context,
     ):
         """

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -34,6 +34,9 @@ new GitHubOidcStack(app, "GitHubOidcStack", {
     new FrontendStack(app, `Frontend-${stageType.toLowerCase()}`, {
         env,
         stageType,
+        tokenApiDomain: serviceStack.tokenApiDomain,
+        oidcProviderUrl: serviceStack.oidcProviderUrlParam,
+        clientId: serviceStack.clientIdParam,
     });
 });
 

--- a/lib/stacks/frontend.ts
+++ b/lib/stacks/frontend.ts
@@ -2,6 +2,7 @@ import {Construct} from "constructs";
 import * as path from "path";
 
 import {Duration, RemovalPolicy, Stack, StackProps} from "aws-cdk-lib";
+import {IStringParameter} from "aws-cdk-lib/aws-ssm";
 import {Certificate, DnsValidatedCertificate} from "aws-cdk-lib/aws-certificatemanager";
 import {
     Distribution,
@@ -19,6 +20,9 @@ import {BASE_DOMAIN, HOSTED_ZONE_ID, StageType} from "../config";
 
 export interface FrontendStackProps extends StackProps {
     stageType: StageType;
+    tokenApiDomain: string;
+    oidcProviderUrl: IStringParameter;
+    clientId: IStringParameter;
 }
 
 export class FrontendStack extends Stack {
@@ -106,7 +110,16 @@ export class FrontendStack extends Stack {
         });
 
         new BucketDeployment(this, "DeployFrontend", {
-            sources: [Source.asset(path.join(__dirname, "../../frontend/dist"))],
+            sources: [
+                Source.asset(path.join(__dirname, "../../frontend/dist")),
+                Source.jsonData("config.json", {
+                    oidcProviderUrl: this.props.oidcProviderUrl.stringValue,
+                    clientId: this.props.clientId.stringValue,
+                    redirectUri: `https://${this.domainName}`,
+                    tokenServerUrl: `https://${this.props.tokenApiDomain}`,
+                    scopes: ["openid", "profile", "email"],
+                }),
+            ],
             destinationBucket: this.bucket,
             distribution,
             distributionPaths: ["/*"],

--- a/lib/stacks/service.ts
+++ b/lib/stacks/service.ts
@@ -32,7 +32,7 @@ import {
     RecordType,
 } from "aws-cdk-lib/aws-route53";
 import {ApiGateway} from "aws-cdk-lib/aws-route53-targets";
-import {Secret} from "aws-cdk-lib/aws-secretsmanager";
+import {IStringParameter, StringParameter} from "aws-cdk-lib/aws-ssm";
 
 import {BASE_DOMAIN, HOSTED_ZONE_ID, StageType} from "../config";
 import {Service} from "../config/service";
@@ -48,8 +48,15 @@ export class ServiceStack extends Stack {
     private readonly hostedZone: IHostedZone;
     private readonly apiExecuteRole: Role;
 
+    public readonly oidcProviderUrlParam: IStringParameter;
+    public readonly clientIdParam: IStringParameter;
+
     private get stageBaseDomain(): string {
         return `${this.props.stageType.toLowerCase()}.${BASE_DOMAIN}`;
+    }
+
+    public get tokenApiDomain(): string {
+        return `${Service.TOKEN}.${this.props.stageType}.${BASE_DOMAIN}`;
     }
 
     // Token Service
@@ -74,6 +81,13 @@ export class ServiceStack extends Stack {
             zoneName: BASE_DOMAIN,
         });
         this.apiExecuteRole = this.buildApiExecuteRole();
+
+        this.oidcProviderUrlParam = StringParameter.fromStringParameterName(
+            this, "OidcProviderUrl", `/ffsync/${props.stageType.toLowerCase()}/oidc-provider-url`,
+        );
+        this.clientIdParam = StringParameter.fromStringParameterName(
+            this, "ClientId", `/ffsync/${props.stageType.toLowerCase()}/client-id`,
+        );
 
         // Tables
         this.tokenUsersTable = this.buildTokenUsersTable();
@@ -212,11 +226,6 @@ export class ServiceStack extends Stack {
     }
 
     private buildTokenApiHandler(): PythonFunction {
-        const oidcSecret = new Secret(this, "OidcSecret", {
-            secretName: `ffsync-oidc-config-${this.props.stageType.toLowerCase()}`,
-            description: "OIDC provider configuration for Token Server",
-        });
-
         const fn = new PythonFunction(this, "TokenApiHandler", {
             entry: path.join(__dirname, "../../lambda"),
             index: "src/entrypoint/__init__.py",
@@ -229,7 +238,8 @@ export class ServiceStack extends Stack {
             environment: {
                 STAGE: this.props.stageType.toLowerCase(),
                 BASE_DOMAIN: this.stageBaseDomain,
-                OIDC_SECRET_ARN: oidcSecret.secretArn,
+                OIDC_PROVIDER_URL: this.oidcProviderUrlParam.stringValue,
+                OIDC_CLIENT_ID: this.clientIdParam.stringValue,
                 TOKEN_USERS_TABLE_NAME: this.tokenUsersTable.tableName,
                 TOKEN_CACHE_TABLE_NAME: this.tokenCacheTable.tableName,
                 CLOCK_SKEW_TOLERANCE: "300",
@@ -241,7 +251,6 @@ export class ServiceStack extends Stack {
         });
 
         // Grant permissions
-        oidcSecret.grantRead(fn);
         this.tokenUsersTable.grantReadWriteData(fn);
         this.tokenCacheTable.grantReadWriteData(fn);
         fn.grantInvoke(this.apiExecuteRole);

--- a/test/frontend.test.ts
+++ b/test/frontend.test.ts
@@ -1,8 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import {App} from "aws-cdk-lib";
+import {App, Stack} from "aws-cdk-lib";
 import {Template} from "aws-cdk-lib/assertions";
+import {StringParameter} from "aws-cdk-lib/aws-ssm";
 
 import {StageType} from "../lib/config";
 import {FrontendStack} from "../lib/stacks/frontend";
@@ -22,9 +23,15 @@ afterAll(() => {
 describe("FrontendStack", () => {
     test("synthesizes expected resources", () => {
         const app = new App();
+        const helperStack = new Stack(app, "HelperStack", {
+            env: {account: "123456789012", region: "us-west-2"},
+        });
         const stack = new FrontendStack(app, "TestFrontend", {
             env: {account: "123456789012", region: "us-west-2"},
             stageType: StageType.PROD,
+            tokenApiDomain: "api.example.com",
+            oidcProviderUrl: StringParameter.fromStringParameterName(helperStack, "OidcParam", "/test/oidc-url"),
+            clientId: StringParameter.fromStringParameterName(helperStack, "ClientIdParam", "/test/client-id"),
         });
 
         const template = Template.fromStack(stack);


### PR DESCRIPTION
## Summary

- Replace static `config.json` with deploy-time generation using CDK `Source.jsonData()` and SSM Parameters
- Migrate Lambda OIDC config from Secrets Manager to environment variables (`OIDC_PROVIDER_URL`, `OIDC_CLIENT_ID`) for consistency
- `FrontendStack` now depends on `ServiceStack` via cross-stack references for the token API domain
- Remove Secrets Manager secret and all related test infrastructure (-385 lines, +78 lines)

## Pre-deploy steps

Create SSM parameters before deploying:

```bash
aws ssm put-parameter --name /ffsync/prod/oidc-provider-url --value "https://..." --type String
aws ssm put-parameter --name /ffsync/prod/client-id --value "..." --type String
```

## Test plan

- [x] All 639 Lambda tests pass with 100% coverage
- [x] CDK TypeScript compiles cleanly
- [x] Frontend builds successfully
- [ ] Deploy to prod after SSM parameters are created
- [ ] Verify config.json is served correctly from CloudFront