### PR TITLE
feat: add CORS support to Token Server for frontend access

### DIFF
--- a/lambda/src/environment/service_provider.py
+++ b/lambda/src/environment/service_provider.py
@@ -2,6 +2,7 @@ import os
 from functools import cached_property
 
 import boto3
+from aws_lambda_powertools.event_handler import CORSConfig
 
 from src.routes.bso.delete import DeleteBSORoute
 from src.routes.bso.read import ReadBSORoute
@@ -152,6 +153,11 @@ class ServiceProvider:
     @cached_property
     def token_api_router(self):
         """Create API router for Token API with RequestTokenRoute"""
+        cors = CORSConfig(
+            allow_origin=f"https://{self.base_domain}",
+            allow_headers=["Authorization", "Content-Type", "X-Client-State"],
+            max_age=3600,
+        )
         return ApiRouter(
             routes=[
                 GetTokenRoute(
@@ -162,6 +168,7 @@ class ServiceProvider:
                 ),
             ],
             middlewares=[WeaveTimestampMiddleware()],
+            cors=cors,
         )
 
     # HAWK Authorizer properties

--- a/lambda/src/services/api_router.py
+++ b/lambda/src/services/api_router.py
@@ -2,7 +2,7 @@ import time
 from typing import Any, Sequence
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver, CORSConfig, Response
 from aws_lambda_powertools.event_handler.middlewares import BaseMiddlewareHandler, NextMiddleware
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
@@ -110,8 +110,9 @@ class ApiRouter:
         self,
         routes: list[BaseRoute],
         middlewares: Sequence[BaseMiddlewareHandler[Any]],
+        cors: CORSConfig | None = None,
     ):
-        self.app = APIGatewayRestResolver()
+        self.app = APIGatewayRestResolver(cors=cors)
         self._routes = routes
         self._middlewares = middlewares
 

--- a/lib/stacks/service.ts
+++ b/lib/stacks/service.ts
@@ -327,6 +327,9 @@ export class ServiceStack extends Stack {
 
         openApiJson = openApiJson.replace(/CDK_LAMBDA_FUNCTION_ARN/g, handler.functionArn);
         openApiJson = openApiJson.replace(/CDK_API_ROLE_ARN/g, this.apiExecuteRole.roleArn);
+        openApiJson = openApiJson.replace(
+            /CDK_CORS_ORIGIN/g, `https://${this.stageBaseDomain}`,
+        );
 
         // Add HAWK authorizer to Storage API
         if (service === Service.STORAGE) {

--- a/smithy/models/main.smithy
+++ b/smithy/models/main.smithy
@@ -50,6 +50,10 @@ service StorageService {
     ]
 }
 
+@cors(
+    origin: "CDK_CORS_ORIGIN"
+    additionalAllowedHeaders: ["Authorization", "X-Client-State"]
+)
 @restJson1
 @documentation("Firefox Sync Token Server - Issues authentication tokens for accessing the Storage API")
 @integration(


### PR DESCRIPTION
## Summary

- Adds Smithy `@cors` trait to `TokenService` with `CDK_CORS_ORIGIN` placeholder, generating OPTIONS mock integration (preflight without Lambda invocation), gateway responses (4XX/5XX with CORS headers), and CORS headers on all response definitions
- CDK replaces `CDK_CORS_ORIGIN` with the stage-specific frontend origin (`https://{stage}.ffsync.layertwo.dev`)
- Adds Powertools `CORSConfig` to the Token API Lambda so actual responses include `Access-Control-Allow-Origin` (required because `aws_proxy` integration passes Lambda responses through directly)

## Test plan

- [ ] Deploy to prod and verify the frontend at `prod.ffsync.layertwo.dev` can reach the Token Server without CORS errors
- [ ] Verify OPTIONS preflight to `token.prod.ffsync.layertwo.dev/1.0/sync/1.5` returns CORS headers
- [ ] Verify GET responses include `Access-Control-Allow-Origin` header