### PR TITLE
fix: serve .well-known/fxa-client-configuration via CloudFront Function

### DIFF
--- a/lib/stacks/frontend.ts
+++ b/lib/stacks/frontend.ts
@@ -6,6 +6,9 @@ import {IStringParameter} from "aws-cdk-lib/aws-ssm";
 import {Certificate, DnsValidatedCertificate} from "aws-cdk-lib/aws-certificatemanager";
 import {
     Distribution,
+    Function as CfFunction,
+    FunctionCode,
+    FunctionEventType,
     PriceClass,
     SecurityPolicyProtocol,
     ViewerProtocolPolicy,
@@ -73,10 +76,40 @@ export class FrontendStack extends Stack {
     }
 
     private buildDistribution(): Distribution {
+        const configJson = JSON.stringify({
+            auth_server_base_url: `https://${this.props.authApiDomain}`,
+            oauth_server_base_url: `https://${this.props.authApiDomain}`,
+            profile_server_base_url: `https://${this.props.authApiDomain}`,
+            sync_tokenserver_base_url: `https://${this.props.authApiDomain}`,
+        });
+
+        const wellKnownFn = new CfFunction(this, "WellKnownFunction", {
+            code: FunctionCode.fromInline([
+                "function handler(event) {",
+                "  if (event.request.uri === '/.well-known/fxa-client-configuration') {",
+                "    return {",
+                "      statusCode: 200,",
+                "      statusDescription: 'OK',",
+                "      headers: {",
+                "        'content-type': { value: 'application/json' },",
+                "        'cache-control': { value: 'public, max-age=3600' }",
+                "      },",
+                `      body: '${configJson}'`,
+                "    };",
+                "  }",
+                "  return event.request;",
+                "}",
+            ].join("\n")),
+        });
+
         const distribution = new Distribution(this, "Distribution", {
             defaultBehavior: {
                 origin: S3BucketOrigin.withOriginAccessControl(this.bucket),
                 viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+                functionAssociations: [{
+                    function: wellKnownFn,
+                    eventType: FunctionEventType.VIEWER_REQUEST,
+                }],
             },
             domainNames: [this.domainName],
             certificate: this.certificate,
@@ -118,12 +151,6 @@ export class FrontendStack extends Stack {
                     redirectUri: `https://${this.domainName}`,
                     authServerUrl: `https://${this.props.authApiDomain}`,
                     scopes: ["openid", "profile", "email"],
-                }),
-                Source.jsonData(".well-known/fxa-client-configuration", {
-                    auth_server_base_url: `https://${this.props.authApiDomain}`,
-                    oauth_server_base_url: `https://${this.props.authApiDomain}`,
-                    profile_server_base_url: `https://${this.props.authApiDomain}`,
-                    sync_tokenserver_base_url: `https://${this.props.authApiDomain}`,
                 }),
             ],
             destinationBucket: this.bucket,


### PR DESCRIPTION
## Summary
- CDK's `Source.jsonData` with a `.well-known/` dotfile path was silently dropped during BucketDeployment zip extraction, so the file never appeared in S3
- Replaced with a CloudFront Function that intercepts `/.well-known/fxa-client-configuration` requests at the edge and returns the JSON response directly
- This also fixes a content-type issue — S3 would have served the extensionless file as `application/octet-stream` instead of `application/json`

## Test plan
- [ ] Deploy the frontend stack with `cdk deploy`
- [ ] Verify `curl https://prod.ffsync.layertwo.dev/.well-known/fxa-client-configuration` returns JSON with the correct auth server URLs
- [ ] Set `identity.fxaccounts.autoconfig.uri` in Firefox `about:config` and verify Firefox discovers the service endpoints