### PR TITLE
feat: make FxA sign-in flow the default frontend route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Routes, Route, useSearchParams, Link } from "react-router"
+import { Routes, Route, useSearchParams } from "react-router"
 import type { AppConfig, AppState, OIDCConfiguration } from "@/lib/types"
 import { checkBrowserCompatibility } from "@/lib/browser-check"
 import { loadConfig } from "@/lib/config"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Routes, Route, useSearchParams } from "react-router"
+import { Routes, Route, useSearchParams, Link } from "react-router"
 import type { AppConfig, AppState, OIDCConfiguration } from "@/lib/types"
 import { checkBrowserCompatibility } from "@/lib/browser-check"
 import { loadConfig } from "@/lib/config"
@@ -213,9 +213,8 @@ export default function App() {
   return (
     <Layout>
       <Routes>
-        <Route path="/signin" element={<FxAFlow />} />
-        <Route path="/signup" element={<FxAFlow />} />
-        <Route path="*" element={<ManualSetupFlow />} />
+        <Route path="/manual" element={<ManualSetupFlow />} />
+        <Route path="*" element={<FxAFlow />} />
       </Routes>
     </Layout>
   )

--- a/frontend/src/components/SignInPage.tsx
+++ b/frontend/src/components/SignInPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { Link } from "react-router"
 import { LogIn, CheckCircle2, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -274,6 +275,12 @@ export function SignInPage({
             <LogIn className="mr-2 h-4 w-4" />
             Continue with identity provider
           </Button>
+          <p className="text-center text-xs text-muted-foreground">
+            <Link to="/manual" className="underline hover:text-foreground">
+              Manual setup
+            </Link>{" "}
+            — configure Firefox Sync via about:config instead
+          </p>
         </CardContent>
       </Card>
     )

--- a/lib/stacks/frontend.ts
+++ b/lib/stacks/frontend.ts
@@ -81,6 +81,7 @@ export class FrontendStack extends Stack {
             oauth_server_base_url: `https://${this.props.authApiDomain}`,
             profile_server_base_url: `https://${this.props.authApiDomain}`,
             sync_tokenserver_base_url: `https://${this.props.authApiDomain}`,
+            content_url: `https://${this.domainName}`,
         });
 
         const wellKnownFn = new CfFunction(this, "WellKnownFunction", {


### PR DESCRIPTION
## Summary
- Makes the FxA-compatible sign-in flow (WebChannel + OIDC + sync password) the default route at `/` instead of requiring `/signin` or `/signup`
- Moves the manual setup flow (about:config-based) to `/manual` with a link from the sign-in page
- Adds `content_url` to `.well-known/fxa-client-configuration` so Firefox knows the content server URL

## Test plan
- [ ] Load `prod.ffsync.layertwo.dev` directly — should show the FxA sign-in flow
- [ ] Firefox autoconfig should navigate to the sign-in page correctly
- [ ] "Manual setup" link on the sign-in page navigates to `/manual`
- [ ] `/manual` shows the original manual setup flow