### PR TITLE
feat: proxy OIDC calls through auth server and fix redirect_uri

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,7 +65,7 @@ function ManualSetupFlow() {
           kind: "processing",
           message: "Discovering OIDC endpoints...",
         })
-        const oidcConfig = await discoverOIDC(cfg.oidcProviderUrl)
+        const oidcConfig = await discoverOIDC(cfg.authServerUrl!)
         setOidc(oidcConfig)
 
         const callbackParams = detectCallback()

--- a/frontend/src/components/SignInPage.tsx
+++ b/frontend/src/components/SignInPage.tsx
@@ -241,12 +241,11 @@ export function SignInPage({
 
   function handleStartOIDC() {
     discoverOIDC(config.authServerUrl!).then((oidcConfig: OIDCConfiguration) => {
-      const currentUrl = new URL(window.location.href)
-      const redirectConfig = {
-        ...config,
-        redirectUri: `${currentUrl.origin}${currentUrl.pathname}${currentUrl.search}`,
+      // Stash Firefox's query params so they survive the OIDC redirect round-trip
+      if (window.location.search) {
+        session.storeFxAParams(window.location.search)
       }
-      initiateOAuthFlow(redirectConfig, oidcConfig)
+      initiateOAuthFlow(config, oidcConfig)
     }).catch((err: unknown) => {
       handleError(err instanceof Error ? err.message : String(err))
     })

--- a/frontend/src/components/SignInPage.tsx
+++ b/frontend/src/components/SignInPage.tsx
@@ -118,12 +118,12 @@ export function SignInPage({
 
       const code = validateCallback(params)
 
-      const oidcConfig = await discoverOIDC(config.oidcProviderUrl)
+      const oidcConfig = await discoverOIDC(config.authServerUrl!)
       const tokens = await exchangeCodeForToken(config, oidcConfig, code)
       const accessToken = tokens.access_token
 
       const email = await extractEmailFromToken(
-        config.oidcProviderUrl,
+        oidcConfig.userinfoEndpoint,
         accessToken
       )
 
@@ -240,7 +240,7 @@ export function SignInPage({
   }
 
   function handleStartOIDC() {
-    discoverOIDC(config.oidcProviderUrl).then((oidcConfig: OIDCConfiguration) => {
+    discoverOIDC(config.authServerUrl!).then((oidcConfig: OIDCConfiguration) => {
       const currentUrl = new URL(window.location.href)
       const redirectConfig = {
         ...config,
@@ -356,12 +356,12 @@ export function SignInPage({
 }
 
 async function extractEmailFromToken(
-  providerUrl: string,
+  userinfoEndpoint: string,
   accessToken: string
 ): Promise<string> {
   let response: Response
   try {
-    response = await fetch(`${providerUrl}/userinfo`, {
+    response = await fetch(userinfoEndpoint, {
       headers: { Authorization: `Bearer ${accessToken}` },
     })
   } catch {

--- a/frontend/src/lib/oidc.ts
+++ b/frontend/src/lib/oidc.ts
@@ -2,26 +2,26 @@ import * as session from "./session"
 import type { OIDCConfiguration } from "./types"
 
 export async function discoverOIDC(
-  providerUrl: string
+  authServerUrl: string
 ): Promise<OIDCConfiguration> {
   const cached = session.getOIDCConfig()
   if (cached) {
     return JSON.parse(cached) as OIDCConfiguration
   }
 
-  const url = `${providerUrl}/.well-known/openid-configuration`
+  const url = `${authServerUrl}/v1/oidc/config`
   let response: Response
   try {
     response = await fetch(url)
   } catch {
     throw new Error(
-      `Could not reach the OIDC provider at ${providerUrl}. Check your network connection and provider URL.`
+      `Could not reach the auth server at ${authServerUrl}. Check your network connection and server URL.`
     )
   }
 
   if (!response.ok) {
     throw new Error(
-      `OIDC discovery failed (${response.status}) from ${url}. Verify the OIDC provider URL is correct.`
+      `OIDC discovery failed (${response.status}) from ${url}. Verify the auth server URL is correct.`
     )
   }
 
@@ -37,6 +37,7 @@ export async function discoverOIDC(
     issuer: data.issuer,
     authorizationEndpoint: data.authorization_endpoint,
     tokenEndpoint: data.token_endpoint,
+    userinfoEndpoint: data.userinfo_endpoint,
   }
 
   session.storeOIDCConfig(JSON.stringify(config))

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -2,6 +2,7 @@ const KEYS = {
   codeVerifier: "ffsync_code_verifier",
   state: "ffsync_state",
   oidcConfig: "ffsync_oidc_config",
+  fxaParams: "ffsync_fxa_params",
 } as const
 
 export function storeCodeVerifier(verifier: string): void {
@@ -36,8 +37,21 @@ export function getOIDCConfig(): string | null {
   return sessionStorage.getItem(KEYS.oidcConfig)
 }
 
+export function storeFxAParams(params: string): void {
+  sessionStorage.setItem(KEYS.fxaParams, params)
+}
+
+export function getFxAParams(): string | null {
+  return sessionStorage.getItem(KEYS.fxaParams)
+}
+
+export function removeFxAParams(): void {
+  sessionStorage.removeItem(KEYS.fxaParams)
+}
+
 export function clearAll(): void {
   sessionStorage.removeItem(KEYS.codeVerifier)
   sessionStorage.removeItem(KEYS.state)
   sessionStorage.removeItem(KEYS.oidcConfig)
+  sessionStorage.removeItem(KEYS.fxaParams)
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -11,6 +11,7 @@ export interface OIDCConfiguration {
   issuer: string
   authorizationEndpoint: string
   tokenEndpoint: string
+  userinfoEndpoint: string
 }
 
 export interface TokenResponse {

--- a/lambda/src/environment/service_provider.py
+++ b/lambda/src/environment/service_provider.py
@@ -14,6 +14,7 @@ from src.routes.auth.oauth_authorization import OAuthAuthorizationRoute
 from src.routes.auth.oauth_destroy import OAuthDestroyRoute
 from src.routes.auth.oauth_token import OAuthTokenRoute
 from src.routes.auth.oidc_discovery import OIDCDiscoveryRoute
+from src.routes.auth.oidc_proxy import OIDCProxyConfigRoute, OIDCProxyTokenRoute, OIDCProxyUserinfoRoute
 from src.routes.auth.scoped_key_data import ScopedKeyDataRoute
 from src.routes.auth.session_destroy import SessionDestroyRoute
 from src.routes.auth.session_status import SessionStatusRoute
@@ -269,6 +270,13 @@ class ServiceProvider:
                 # Discovery routes
                 OIDCDiscoveryRoute(jwt_service=self.jwt_service),
                 JWKSRoute(jwt_service=self.jwt_service),
+                # OIDC proxy routes (eliminate CORS issues with external provider)
+                OIDCProxyConfigRoute(
+                    oidc_validator=self.oidc_validator,
+                    auth_server_base_url=f"https://auth.{self.base_domain}",
+                ),
+                OIDCProxyTokenRoute(oidc_validator=self.oidc_validator),
+                OIDCProxyUserinfoRoute(oidc_validator=self.oidc_validator),
             ],
             middlewares=[WeaveTimestampMiddleware()],
             cors=cors,

--- a/lambda/src/environment/service_provider.py
+++ b/lambda/src/environment/service_provider.py
@@ -14,7 +14,11 @@ from src.routes.auth.oauth_authorization import OAuthAuthorizationRoute
 from src.routes.auth.oauth_destroy import OAuthDestroyRoute
 from src.routes.auth.oauth_token import OAuthTokenRoute
 from src.routes.auth.oidc_discovery import OIDCDiscoveryRoute
-from src.routes.auth.oidc_proxy import OIDCProxyConfigRoute, OIDCProxyTokenRoute, OIDCProxyUserinfoRoute
+from src.routes.auth.oidc_proxy import (
+    OIDCProxyConfigRoute,
+    OIDCProxyTokenRoute,
+    OIDCProxyUserinfoRoute,
+)
 from src.routes.auth.scoped_key_data import ScopedKeyDataRoute
 from src.routes.auth.session_destroy import SessionDestroyRoute
 from src.routes.auth.session_status import SessionStatusRoute

--- a/lambda/src/routes/auth/oidc_proxy.py
+++ b/lambda/src/routes/auth/oidc_proxy.py
@@ -1,0 +1,121 @@
+"""OIDC Proxy routes — proxy OIDC provider calls through the auth server.
+
+Eliminates CORS issues by making browser-to-OIDC-provider calls server-side.
+The authorization endpoint is NOT proxied since it uses a full-page redirect.
+"""
+
+import json
+
+import requests as http_requests
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
+
+from src.services.oidc_validator import OIDCValidator
+from src.shared.base_route import BaseRoute
+
+
+class OIDCProxyConfigRoute(BaseRoute):
+    """GET /v1/oidc/config — return OIDC provider discovery with proxied endpoints."""
+
+    def __init__(self, oidc_validator: OIDCValidator, auth_server_base_url: str):
+        self._oidc_validator = oidc_validator
+        self._auth_server_base_url = auth_server_base_url
+
+    def bind(self, app: APIGatewayRestResolver):
+        @app.get("/v1/oidc/config")
+        def handle_oidc_proxy_config():
+            return self.handle(app.current_event)
+
+    def handle(self, event) -> Response:
+        try:
+            config = self._oidc_validator.discover_provider_config()
+            return Response(
+                status_code=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "issuer": config.issuer,
+                    "authorization_endpoint": config.authorization_endpoint,
+                    "token_endpoint": f"{self._auth_server_base_url}/v1/oidc/token",
+                    "userinfo_endpoint": f"{self._auth_server_base_url}/v1/oidc/userinfo",
+                }),
+            )
+        except Exception:
+            return Response(
+                status_code=502,
+                content_type="application/json",
+                body=json.dumps({"error": "Failed to fetch OIDC provider configuration"}),
+            )
+
+
+class OIDCProxyTokenRoute(BaseRoute):
+    """POST /v1/oidc/token — proxy token exchange to the OIDC provider."""
+
+    def __init__(self, oidc_validator: OIDCValidator):
+        self._oidc_validator = oidc_validator
+
+    def bind(self, app: APIGatewayRestResolver):
+        @app.post("/v1/oidc/token")
+        def handle_oidc_proxy_token():
+            return self.handle(app.current_event)
+
+    def handle(self, event) -> Response:
+        try:
+            config = self._oidc_validator.discover_provider_config()
+
+            body = event.get("body", "")
+            resp = http_requests.post(
+                config.token_endpoint,
+                data=body,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=10,
+            )
+
+            return Response(
+                status_code=resp.status_code,
+                content_type="application/json",
+                body=resp.text,
+            )
+        except Exception:
+            return Response(
+                status_code=502,
+                content_type="application/json",
+                body=json.dumps({"error": "Failed to exchange token with OIDC provider"}),
+            )
+
+
+class OIDCProxyUserinfoRoute(BaseRoute):
+    """GET /v1/oidc/userinfo — proxy userinfo request to the OIDC provider."""
+
+    def __init__(self, oidc_validator: OIDCValidator):
+        self._oidc_validator = oidc_validator
+
+    def bind(self, app: APIGatewayRestResolver):
+        @app.get("/v1/oidc/userinfo")
+        def handle_oidc_proxy_userinfo():
+            return self.handle(app.current_event)
+
+    def handle(self, event) -> Response:
+        try:
+            config = self._oidc_validator.discover_provider_config()
+
+            headers = {}
+            auth_header = event.get("headers", {}).get("Authorization", "")
+            if auth_header:
+                headers["Authorization"] = auth_header
+
+            resp = http_requests.get(
+                config.userinfo_endpoint,
+                headers=headers,
+                timeout=10,
+            )
+
+            return Response(
+                status_code=resp.status_code,
+                content_type="application/json",
+                body=resp.text,
+            )
+        except Exception:
+            return Response(
+                status_code=502,
+                content_type="application/json",
+                body=json.dumps({"error": "Failed to fetch user info from OIDC provider"}),
+            )

--- a/lambda/src/routes/auth/oidc_proxy.py
+++ b/lambda/src/routes/auth/oidc_proxy.py
@@ -31,12 +31,14 @@ class OIDCProxyConfigRoute(BaseRoute):
             return Response(
                 status_code=200,
                 content_type="application/json",
-                body=json.dumps({
-                    "issuer": config.issuer,
-                    "authorization_endpoint": config.authorization_endpoint,
-                    "token_endpoint": f"{self._auth_server_base_url}/v1/oidc/token",
-                    "userinfo_endpoint": f"{self._auth_server_base_url}/v1/oidc/userinfo",
-                }),
+                body=json.dumps(
+                    {
+                        "issuer": config.issuer,
+                        "authorization_endpoint": config.authorization_endpoint,
+                        "token_endpoint": f"{self._auth_server_base_url}/v1/oidc/token",
+                        "userinfo_endpoint": f"{self._auth_server_base_url}/v1/oidc/userinfo",
+                    }
+                ),
             )
         except Exception:
             return Response(

--- a/lambda/tests/routes/auth/test_oidc_proxy.py
+++ b/lambda/tests/routes/auth/test_oidc_proxy.py
@@ -1,0 +1,330 @@
+"""Unit tests for OIDC proxy routes"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
+
+from src.entrypoint import auth_api_handler
+from src.routes.auth.oidc_proxy import (
+    OIDCProxyConfigRoute,
+    OIDCProxyTokenRoute,
+    OIDCProxyUserinfoRoute,
+)
+from src.shared.oidc import OIDCProviderConfig
+
+
+@pytest.fixture
+def provider_config():
+    return OIDCProviderConfig(
+        issuer="https://idp.example.com",
+        jwks_uri="https://idp.example.com/.well-known/jwks.json",
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/oauth/token",
+        userinfo_endpoint="https://idp.example.com/userinfo",
+    )
+
+
+@pytest.fixture
+def mock_oidc_validator(provider_config):
+    validator = MagicMock()
+    validator.discover_provider_config.return_value = provider_config
+    return validator
+
+
+AUTH_SERVER_BASE_URL = "https://auth.beta.ffsync.layertwo.dev"
+
+
+# --- OIDCProxyConfigRoute ---
+
+
+class TestOIDCProxyConfigRoute:
+    @pytest.fixture
+    def route(self, mock_oidc_validator):
+        return OIDCProxyConfigRoute(
+            oidc_validator=mock_oidc_validator,
+            auth_server_base_url=AUTH_SERVER_BASE_URL,
+        )
+
+    def test_returns_config_with_proxied_endpoints(self, route):
+        event = APIGatewayProxyEvent(
+            {"httpMethod": "GET", "path": "/v1/oidc/config", "headers": {}}
+        )
+        response = route.handle(event)
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["issuer"] == "https://idp.example.com"
+        assert body["authorization_endpoint"] == "https://idp.example.com/authorize"
+        assert body["token_endpoint"] == f"{AUTH_SERVER_BASE_URL}/v1/oidc/token"
+        assert body["userinfo_endpoint"] == f"{AUTH_SERVER_BASE_URL}/v1/oidc/userinfo"
+
+    def test_returns_502_on_discovery_failure(self, mock_oidc_validator):
+        mock_oidc_validator.discover_provider_config.side_effect = Exception("unreachable")
+        route = OIDCProxyConfigRoute(
+            oidc_validator=mock_oidc_validator,
+            auth_server_base_url=AUTH_SERVER_BASE_URL,
+        )
+        event = APIGatewayProxyEvent(
+            {"httpMethod": "GET", "path": "/v1/oidc/config", "headers": {}}
+        )
+        response = route.handle(event)
+        assert response.status_code == 502
+        body = json.loads(response.body)
+        assert "error" in body
+
+    def test_bind_registers_get_route(self, route):
+        mock_api = MagicMock()
+        mock_api.get = MagicMock(return_value=lambda f: f)
+        route.bind(mock_api)
+        mock_api.get.assert_called_once_with("/v1/oidc/config")
+
+
+# --- OIDCProxyTokenRoute ---
+
+
+class TestOIDCProxyTokenRoute:
+    @pytest.fixture
+    def route(self, mock_oidc_validator):
+        return OIDCProxyTokenRoute(oidc_validator=mock_oidc_validator)
+
+    @patch("src.routes.auth.oidc_proxy.http_requests")
+    def test_proxies_token_exchange(self, mock_requests, route):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps({"access_token": "tok123", "token_type": "Bearer"})
+        mock_requests.post.return_value = mock_response
+
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "POST",
+                "path": "/v1/oidc/token",
+                "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+                "body": "grant_type=authorization_code&code=abc",
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["access_token"] == "tok123"
+
+        mock_requests.post.assert_called_once_with(
+            "https://idp.example.com/oauth/token",
+            data="grant_type=authorization_code&code=abc",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=10,
+        )
+
+    @patch("src.routes.auth.oidc_proxy.http_requests")
+    def test_forwards_provider_error_status(self, mock_requests, route):
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = json.dumps({"error": "invalid_grant"})
+        mock_requests.post.return_value = mock_response
+
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "POST",
+                "path": "/v1/oidc/token",
+                "headers": {},
+                "body": "grant_type=authorization_code&code=bad",
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 400
+        body = json.loads(response.body)
+        assert body["error"] == "invalid_grant"
+
+    def test_returns_502_on_discovery_failure(self, mock_oidc_validator):
+        mock_oidc_validator.discover_provider_config.side_effect = Exception("unreachable")
+        route = OIDCProxyTokenRoute(oidc_validator=mock_oidc_validator)
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "POST",
+                "path": "/v1/oidc/token",
+                "headers": {},
+                "body": "",
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 502
+
+    def test_bind_registers_post_route(self, route):
+        mock_api = MagicMock()
+        mock_api.post = MagicMock(return_value=lambda f: f)
+        route.bind(mock_api)
+        mock_api.post.assert_called_once_with("/v1/oidc/token")
+
+
+# --- OIDCProxyUserinfoRoute ---
+
+
+class TestOIDCProxyUserinfoRoute:
+    @pytest.fixture
+    def route(self, mock_oidc_validator):
+        return OIDCProxyUserinfoRoute(oidc_validator=mock_oidc_validator)
+
+    @patch("src.routes.auth.oidc_proxy.http_requests")
+    def test_proxies_userinfo_with_auth_header(self, mock_requests, route):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps({"email": "user@example.com", "sub": "abc123"})
+        mock_requests.get.return_value = mock_response
+
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "GET",
+                "path": "/v1/oidc/userinfo",
+                "headers": {"Authorization": "Bearer tok123"},
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["email"] == "user@example.com"
+
+        mock_requests.get.assert_called_once_with(
+            "https://idp.example.com/userinfo",
+            headers={"Authorization": "Bearer tok123"},
+            timeout=10,
+        )
+
+    @patch("src.routes.auth.oidc_proxy.http_requests")
+    def test_proxies_userinfo_without_auth_header(self, mock_requests, route):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = json.dumps({"error": "unauthorized"})
+        mock_requests.get.return_value = mock_response
+
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "GET",
+                "path": "/v1/oidc/userinfo",
+                "headers": {},
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 401
+
+        mock_requests.get.assert_called_once_with(
+            "https://idp.example.com/userinfo",
+            headers={},
+            timeout=10,
+        )
+
+    def test_returns_502_on_discovery_failure(self, mock_oidc_validator):
+        mock_oidc_validator.discover_provider_config.side_effect = Exception("unreachable")
+        route = OIDCProxyUserinfoRoute(oidc_validator=mock_oidc_validator)
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "GET",
+                "path": "/v1/oidc/userinfo",
+                "headers": {"Authorization": "Bearer tok123"},
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 502
+
+    def test_bind_registers_get_route(self, route):
+        mock_api = MagicMock()
+        mock_api.get = MagicMock(return_value=lambda f: f)
+        route.bind(mock_api)
+        mock_api.get.assert_called_once_with("/v1/oidc/userinfo")
+
+
+# --- Integration tests through the full router ---
+
+OIDC_DISCOVERY_RESPONSE = {
+    "issuer": "https://auth.example.com",
+    "jwks_uri": "https://auth.example.com/jwks",
+    "authorization_endpoint": "https://auth.example.com/authorize",
+    "token_endpoint": "https://auth.example.com/token",
+    "userinfo_endpoint": "https://auth.example.com/userinfo",
+}
+
+
+def _make_event(method, path, headers=None, body=None):
+    return {
+        "httpMethod": method,
+        "path": path,
+        "headers": headers or {},
+        "body": body,
+        "queryStringParameters": None,
+        "requestContext": {"requestId": "test-request-id"},
+    }
+
+
+class TestOIDCProxyIntegration:
+    """Integration tests that exercise proxy routes through the auth_api_handler."""
+
+    @patch("src.routes.auth.oidc_proxy.http_requests")
+    @patch("src.services.oidc_validator.requests.get")
+    def test_config_route_through_router(
+        self, mock_discovery_get, mock_proxy_requests, mock_service_provider, sample_lambda_context
+    ):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = OIDC_DISCOVERY_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        mock_discovery_get.return_value = mock_resp
+
+        result = auth_api_handler(
+            _make_event("GET", "/v1/oidc/config"),
+            sample_lambda_context,
+            mock_service_provider,
+        )
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["authorization_endpoint"] == "https://auth.example.com/authorize"
+        assert "/v1/oidc/token" in body["token_endpoint"]
+
+    @patch("src.routes.auth.oidc_proxy.http_requests")
+    @patch("src.services.oidc_validator.requests.get")
+    def test_token_route_through_router(
+        self, mock_discovery_get, mock_proxy_requests, mock_service_provider, sample_lambda_context
+    ):
+        mock_disc_resp = MagicMock()
+        mock_disc_resp.status_code = 200
+        mock_disc_resp.json.return_value = OIDC_DISCOVERY_RESPONSE
+        mock_disc_resp.raise_for_status = MagicMock()
+        mock_discovery_get.return_value = mock_disc_resp
+
+        mock_token_resp = MagicMock()
+        mock_token_resp.status_code = 200
+        mock_token_resp.text = json.dumps({"access_token": "t", "token_type": "Bearer"})
+        mock_proxy_requests.post.return_value = mock_token_resp
+
+        result = auth_api_handler(
+            _make_event(
+                "POST",
+                "/v1/oidc/token",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                body="grant_type=authorization_code&code=abc",
+            ),
+            sample_lambda_context,
+            mock_service_provider,
+        )
+        assert result["statusCode"] == 200
+
+    @patch("src.routes.auth.oidc_proxy.http_requests")
+    @patch("src.services.oidc_validator.requests.get")
+    def test_userinfo_route_through_router(
+        self, mock_discovery_get, mock_proxy_requests, mock_service_provider, sample_lambda_context
+    ):
+        mock_disc_resp = MagicMock()
+        mock_disc_resp.status_code = 200
+        mock_disc_resp.json.return_value = OIDC_DISCOVERY_RESPONSE
+        mock_disc_resp.raise_for_status = MagicMock()
+        mock_discovery_get.return_value = mock_disc_resp
+
+        mock_ui_resp = MagicMock()
+        mock_ui_resp.status_code = 200
+        mock_ui_resp.text = json.dumps({"email": "a@b.com"})
+        mock_proxy_requests.get.return_value = mock_ui_resp
+
+        result = auth_api_handler(
+            _make_event("GET", "/v1/oidc/userinfo", headers={"Authorization": "Bearer tok"}),
+            sample_lambda_context,
+            mock_service_provider,
+        )
+        assert result["statusCode"] == 200

--- a/lambda/tests/routes/auth/test_oidc_proxy.py
+++ b/lambda/tests/routes/auth/test_oidc_proxy.py
@@ -53,6 +53,7 @@ class TestOIDCProxyConfigRoute:
         )
         response = route.handle(event)
         assert response.status_code == 200
+        assert response.body is not None
         body = json.loads(response.body)
         assert body["issuer"] == "https://idp.example.com"
         assert body["authorization_endpoint"] == "https://idp.example.com/authorize"
@@ -70,6 +71,7 @@ class TestOIDCProxyConfigRoute:
         )
         response = route.handle(event)
         assert response.status_code == 502
+        assert response.body is not None
         body = json.loads(response.body)
         assert "error" in body
 
@@ -105,6 +107,7 @@ class TestOIDCProxyTokenRoute:
         )
         response = route.handle(event)
         assert response.status_code == 200
+        assert response.body is not None
         body = json.loads(response.body)
         assert body["access_token"] == "tok123"
 
@@ -132,6 +135,7 @@ class TestOIDCProxyTokenRoute:
         )
         response = route.handle(event)
         assert response.status_code == 400
+        assert response.body is not None
         body = json.loads(response.body)
         assert body["error"] == "invalid_grant"
 
@@ -180,6 +184,7 @@ class TestOIDCProxyUserinfoRoute:
         )
         response = route.handle(event)
         assert response.status_code == 200
+        assert response.body is not None
         body = json.loads(response.body)
         assert body["email"] == "user@example.com"
 


### PR DESCRIPTION
## Summary
- Adds OIDC proxy endpoints (`/v1/oidc/config`, `/v1/oidc/token`, `/v1/oidc/userinfo`) on the auth server so the frontend routes OIDC provider calls server-side, eliminating browser CORS restrictions
- Fixes the `redirect_uri` in the FxA sign-in flow to use the registered callback URL from `config.json` instead of the full `window.location.href` (which included Firefox's query params like `context`, `state`, `code_challenge`, `keys_jwk`, etc.)
- Stashes Firefox query params in `sessionStorage` so they survive the OIDC redirect round-trip

## Test plan
- [ ] OIDC discovery, token exchange, and userinfo calls succeed without CORS errors
- [ ] FxA sign-in flow completes: OIDC login → sync password → Firefox configured
- [ ] `redirect_uri` sent to the OIDC provider matches the registered callback URL
- [ ] 897 Python tests pass at 100% coverage
- [ ] Frontend TypeScript compiles cleanly