### PR TITLE
fix: build full Hawk auth header and switch OIDC route to Powertools Logger

### DIFF
--- a/frontend/src/lib/auth-client.ts
+++ b/frontend/src/lib/auth-client.ts
@@ -1,4 +1,4 @@
-import { deriveSessionTokenId } from "./fxa-crypto"
+import { buildHawkHeader } from "./fxa-crypto"
 
 interface AccountStatusResponse {
   exists: boolean
@@ -123,14 +123,15 @@ export async function requestOAuthCode(
   state: string,
   codeChallenge: string
 ): Promise<OAuthCodeResponse> {
-  const tokenId = await deriveSessionTokenId(sessionToken)
+  const url = `${authServerUrl}/v1/oauth/authorization`
+  const authorization = await buildHawkHeader(sessionToken, "POST", url)
   return authFetch<OAuthCodeResponse>(
-    `${authServerUrl}/v1/oauth/authorization`,
+    url,
     {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Hawk id="${tokenId}"`,
+        Authorization: authorization,
       },
       body: JSON.stringify({
         client_id: clientId,

--- a/frontend/src/lib/fxa-crypto.ts
+++ b/frontend/src/lib/fxa-crypto.ts
@@ -44,6 +44,41 @@ export async function deriveSessionTokenId(sessionTokenHex: string): Promise<str
   return toHex(derived.slice(0, 32))
 }
 
+export async function buildHawkHeader(
+  sessionTokenHex: string,
+  method: string,
+  url: string
+): Promise<string> {
+  const tokenBytes = hexToBytes(sessionTokenHex)
+  const derived = await hkdf(tokenBytes.buffer, "identity.mozilla.com/picl/v1/sessionToken", 96)
+
+  const tokenId = toHex(derived.slice(0, 32))
+  const reqHMACKey = derived.slice(32, 64)
+
+  const parsedUrl = new URL(url)
+  const host = parsedUrl.hostname
+  const port = parsedUrl.port || (parsedUrl.protocol === "https:" ? "443" : "80")
+  const path = parsedUrl.pathname + parsedUrl.search
+
+  const ts = Math.floor(Date.now() / 1000).toString()
+  const nonceBytes = crypto.getRandomValues(new Uint8Array(6))
+  const nonce = toHex(nonceBytes.buffer)
+
+  const canonical = `hawk.1.header\n${ts}\n${nonce}\n${method}\n${path}\n${host}\n${port}\n\n\n`
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    reqHMACKey,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  )
+  const mac = await crypto.subtle.sign("HMAC", key, encode(canonical))
+  const macB64 = btoa(String.fromCharCode(...new Uint8Array(mac)))
+
+  return `Hawk id="${tokenId}", ts="${ts}", nonce="${nonce}", mac="${macB64}"`
+}
+
 export async function stretchPassword(
   email: string,
   password: string

--- a/lambda/src/routes/auth/oidc_exchange.py
+++ b/lambda/src/routes/auth/oidc_exchange.py
@@ -1,16 +1,16 @@
 """OIDC exchange routes — GET /v1/oidc/config and POST /v1/oidc/exchange"""
 
 import json
-import logging
 
 import requests as http_requests
+from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
 
 from src.services.auth_account_manager import AuthAccountManager
 from src.services.oidc_validator import OIDCValidator
 from src.shared.base_route import BaseRoute
 
-logger = logging.getLogger(__name__)
+logger = Logger()
 
 
 class OIDCProviderConfigRoute(BaseRoute):


### PR DESCRIPTION
## Summary

- **Fix Hawk auth 401**: `requestOAuthCode` was sending a bare `Hawk id="<tokenId>"` header, but the server expects a full Hawk header with `id`, `ts`, `nonce`, and `mac` fields. The regex at `fxa_token_manager.py:136` always failed to match, returning 401. Added `buildHawkHeader` to `fxa-crypto.ts` that derives both `tokenId` (bytes 0–32) and `reqHMACKey` (bytes 32–64) via HKDF, constructs the Hawk canonical string, computes HMAC-SHA256, and produces a complete Authorization header.
- **Fix missing CloudWatch logs**: `oidc_exchange.py` used `logging.getLogger(__name__)` while every other route file uses the Powertools `Logger`. Standard loggers have no handler configured in Lambda, so logs were silently dropped. Switched to `Logger()` to match the rest of the codebase.

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] `black --check`, `isort --check`, `flake8`, `mypy` all pass
- [x] All 902 unit tests pass with 100% coverage
- [ ] Test full sign-in flow end-to-end to verify Hawk auth works against the deployed server