### PR TITLE
feat: implement Firefox Sync key exchange (keys_jwe)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.1",
+        "jose": "^6.1.3",
         "lucide-react": "^0.575.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2888,6 +2889,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.1",
+    "jose": "^6.1.3",
     "lucide-react": "^0.575.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -204,6 +204,14 @@ function FxAFlow() {
     return <LoadingPage message="Loading configuration..." />
   }
 
+  // After OIDC redirect, original Firefox params are lost from the URL.
+  // Restore from session storage (stored before OIDC redirect in SignInPage).
+  const storedFxAParams = session.getFxAParams()
+  const fxaParams = storedFxAParams
+    ? new URLSearchParams(storedFxAParams)
+    : searchParams
+  const keysJwk = fxaParams.get("keys_jwk") ?? undefined
+
   return (
     <SignInPage
       config={config}
@@ -216,6 +224,7 @@ function FxAFlow() {
         searchParams.get("scope") ??
         "https://identity.mozilla.com/apps/oldsync profile"
       }
+      keysJwk={keysJwk}
     />
   )
 }

--- a/frontend/src/components/SignInPage.tsx
+++ b/frontend/src/components/SignInPage.tsx
@@ -31,6 +31,7 @@ import {
   sendOAuthLogin,
 } from "@/lib/webchannel"
 import { generatePKCE } from "@/lib/pkce"
+import { deriveAndEncryptSyncKeys } from "@/lib/sync-keys"
 import { SyncPasswordForm } from "@/components/SyncPasswordForm"
 
 type SignInState =
@@ -48,6 +49,7 @@ interface SignInPageProps {
   codeChallenge?: string
   clientId: string
   scope: string
+  keysJwk?: string
 }
 
 export function SignInPage({
@@ -58,6 +60,7 @@ export function SignInPage({
   codeChallenge: fxaCodeChallenge,
   clientId: fxaClientId,
   scope: fxaScope,
+  keysJwk,
 }: SignInPageProps) {
   const [signInState, setSignInState] = useState<SignInState>({
     step: "oidc-login",
@@ -211,13 +214,30 @@ export function SignInPage({
         codeVerifier = pkce.codeVerifier
       }
 
+      let keysJwe: string | undefined
+      if (keysJwk) {
+        setSignInState({
+          step: "processing",
+          message: "Deriving sync encryption keys...",
+        })
+        keysJwe = await deriveAndEncryptSyncKeys({
+          authServerUrl: config.authServerUrl,
+          keyFetchTokenHex: keyFetchToken,
+          unwrapBKeyHex: unwrapBKey,
+          sessionTokenHex: sessionToken,
+          keysJwkB64: keysJwk,
+          scope: fxaScope,
+        })
+      }
+
       const oauthResult = await requestOAuthCode(
         config.authServerUrl,
         sessionToken,
         fxaClientId,
         fxaScope,
         oauthState,
-        codeChallenge
+        codeChallenge,
+        keysJwe
       )
 
       setSignInState({
@@ -228,8 +248,6 @@ export function SignInPage({
       sendOAuthLogin(oauthResult.code, oauthResult.state)
 
       void uid
-      void keyFetchToken
-      void unwrapBKey
       void codeVerifier
       void service
       void action

--- a/frontend/src/lib/auth-client.ts
+++ b/frontend/src/lib/auth-client.ts
@@ -17,7 +17,7 @@ interface OAuthCodeResponse {
   redirect: string
 }
 
-async function authFetch<T>(
+export async function authFetch<T>(
   url: string,
   options: RequestInit
 ): Promise<T> {
@@ -121,10 +121,22 @@ export async function requestOAuthCode(
   clientId: string,
   scope: string,
   state: string,
-  codeChallenge: string
+  codeChallenge: string,
+  keysJwe?: string
 ): Promise<OAuthCodeResponse> {
   const url = `${authServerUrl}/v1/oauth/authorization`
   const authorization = await buildHawkHeader(sessionToken, "POST", url)
+  const bodyObj: Record<string, string> = {
+    client_id: clientId,
+    scope,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    access_type: "offline",
+  }
+  if (keysJwe) {
+    bodyObj.keys_jwe = keysJwe
+  }
   return authFetch<OAuthCodeResponse>(
     url,
     {
@@ -133,14 +145,7 @@ export async function requestOAuthCode(
         "Content-Type": "application/json",
         Authorization: authorization,
       },
-      body: JSON.stringify({
-        client_id: clientId,
-        scope,
-        state,
-        code_challenge: codeChallenge,
-        code_challenge_method: "S256",
-        access_type: "offline",
-      }),
+      body: JSON.stringify(bodyObj),
     }
   )
 }

--- a/frontend/src/lib/fxa-crypto.ts
+++ b/frontend/src/lib/fxa-crypto.ts
@@ -10,7 +10,7 @@ export function toHex(buffer: ArrayBuffer): string {
     .join("")
 }
 
-async function hkdf(
+export async function hkdf(
   ikm: ArrayBuffer,
   info: string,
   length: number = 32
@@ -30,7 +30,7 @@ async function hkdf(
   )
 }
 
-function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+export function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
   const bytes = new Uint8Array(hex.length / 2) as Uint8Array<ArrayBuffer>
   for (let i = 0; i < hex.length; i += 2) {
     bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16)
@@ -44,13 +44,14 @@ export async function deriveSessionTokenId(sessionTokenHex: string): Promise<str
   return toHex(derived.slice(0, 32))
 }
 
-export async function buildHawkHeader(
-  sessionTokenHex: string,
+export async function buildHawkHeaderWithInfo(
+  tokenHex: string,
   method: string,
-  url: string
+  url: string,
+  infoString: string
 ): Promise<string> {
-  const tokenBytes = hexToBytes(sessionTokenHex)
-  const derived = await hkdf(tokenBytes.buffer, "identity.mozilla.com/picl/v1/sessionToken", 96)
+  const tokenBytes = hexToBytes(tokenHex)
+  const derived = await hkdf(tokenBytes.buffer, infoString, 96)
 
   const tokenId = toHex(derived.slice(0, 32))
   const reqHMACKey = derived.slice(32, 64)
@@ -77,6 +78,19 @@ export async function buildHawkHeader(
   const macB64 = btoa(String.fromCharCode(...new Uint8Array(mac)))
 
   return `Hawk id="${tokenId}", ts="${ts}", nonce="${nonce}", mac="${macB64}"`
+}
+
+export async function buildHawkHeader(
+  sessionTokenHex: string,
+  method: string,
+  url: string
+): Promise<string> {
+  return buildHawkHeaderWithInfo(
+    sessionTokenHex,
+    method,
+    url,
+    "identity.mozilla.com/picl/v1/sessionToken"
+  )
 }
 
 export async function stretchPassword(

--- a/frontend/src/lib/sync-keys.ts
+++ b/frontend/src/lib/sync-keys.ts
@@ -1,0 +1,236 @@
+import { CompactEncrypt, importJWK } from "jose"
+import {
+  hkdf,
+  hexToBytes,
+  toHex,
+  buildHawkHeaderWithInfo,
+} from "./fxa-crypto"
+import { authFetch } from "./auth-client"
+
+const SESSION_TOKEN_INFO = "identity.mozilla.com/picl/v1/sessionToken"
+const KEY_FETCH_TOKEN_INFO = "identity.mozilla.com/picl/v1/keyFetchToken"
+const ACCOUNT_KEYS_INFO = "identity.mozilla.com/picl/v1/account/keys"
+const OLDSYNC_INFO = "identity.mozilla.com/picl/v1/oldsync"
+
+interface KeyBundle {
+  kA: string
+  wrapKB: string
+}
+
+interface ScopedKeyData {
+  identifier: string
+  keyRotationSecret: string
+  keyRotationTimestamp: number
+}
+
+interface ScopedKeyJWK {
+  kid: string
+  k: string
+  kty: string
+}
+
+export interface DeriveAndEncryptParams {
+  authServerUrl: string
+  keyFetchTokenHex: string
+  unwrapBKeyHex: string
+  sessionTokenHex: string
+  keysJwkB64: string
+  scope: string
+}
+
+export async function fetchAccountKeys(
+  authServerUrl: string,
+  keyFetchTokenHex: string
+): Promise<string> {
+  const url = `${authServerUrl}/v1/account/keys`
+  const authorization = await buildHawkHeaderWithInfo(
+    keyFetchTokenHex,
+    "GET",
+    url,
+    KEY_FETCH_TOKEN_INFO
+  )
+  const response = await authFetch<{ bundle: string }>(url, {
+    method: "GET",
+    headers: { Authorization: authorization },
+  })
+  return response.bundle
+}
+
+export async function decryptKeyBundle(
+  keyFetchTokenHex: string,
+  bundleHex: string
+): Promise<KeyBundle> {
+  const tokenBytes = hexToBytes(keyFetchTokenHex)
+
+  // Derive the bundle key from keyFetchToken
+  const derived = await hkdf(tokenBytes.buffer, KEY_FETCH_TOKEN_INFO, 96)
+  const bundleKey = derived.slice(64, 96)
+
+  // Derive hmacKey and xorKey from bundleKey
+  const keys = await hkdf(bundleKey, ACCOUNT_KEYS_INFO, 96)
+  const hmacKey = keys.slice(0, 32)
+  const xorKey = new Uint8Array(keys.slice(32, 96))
+
+  // Parse the bundle (96 bytes = 64 ciphertext + 32 MAC)
+  const bundleBytes = hexToBytes(bundleHex)
+  const ciphertext = bundleBytes.slice(0, 64)
+  const mac = bundleBytes.slice(64, 96)
+
+  // Verify HMAC-SHA256
+  const hmacCryptoKey = await crypto.subtle.importKey(
+    "raw",
+    hmacKey,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"]
+  )
+  const valid = await crypto.subtle.verify(
+    "HMAC",
+    hmacCryptoKey,
+    mac,
+    ciphertext
+  )
+  if (!valid) {
+    throw new Error("Key bundle HMAC verification failed")
+  }
+
+  // XOR ciphertext with xorKey to get kA + wrapKB
+  const plaintext = new Uint8Array(64)
+  for (let i = 0; i < 64; i++) {
+    plaintext[i] = ciphertext[i] ^ xorKey[i]
+  }
+
+  return {
+    kA: toHex(plaintext.slice(0, 32).buffer),
+    wrapKB: toHex(plaintext.slice(32, 64).buffer),
+  }
+}
+
+export function deriveKB(wrapKBHex: string, unwrapBKeyHex: string): string {
+  const wrapKB = hexToBytes(wrapKBHex)
+  const unwrapBKey = hexToBytes(unwrapBKeyHex)
+  const kB = new Uint8Array(32)
+  for (let i = 0; i < 32; i++) {
+    kB[i] = wrapKB[i] ^ unwrapBKey[i]
+  }
+  return toHex(kB.buffer)
+}
+
+export async function fetchScopedKeyData(
+  authServerUrl: string,
+  sessionTokenHex: string,
+  clientId: string,
+  scope: string
+): Promise<Record<string, ScopedKeyData>> {
+  const url = `${authServerUrl}/v1/account/scoped-key-data`
+  const authorization = await buildHawkHeaderWithInfo(
+    sessionTokenHex,
+    "POST",
+    url,
+    SESSION_TOKEN_INFO
+  )
+  return authFetch<Record<string, ScopedKeyData>>(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authorization,
+    },
+    body: JSON.stringify({ client_id: clientId, scope }),
+  })
+}
+
+function toBase64url(buffer: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")
+}
+
+export async function deriveScopedSyncKey(
+  kBHex: string,
+  keyRotationTimestamp: number
+): Promise<ScopedKeyJWK> {
+  const kB = hexToBytes(kBHex)
+
+  // Derive sync key material (legacy oldsync derivation)
+  const syncKeyMaterial = await hkdf(kB.buffer, OLDSYNC_INFO, 64)
+
+  // Compute fingerprint: SHA-256(kB)[0:16]
+  const kBHash = await crypto.subtle.digest("SHA-256", kB)
+  const fingerprint = toBase64url(kBHash.slice(0, 16))
+
+  return {
+    kid: `${keyRotationTimestamp}-${fingerprint}`,
+    k: toBase64url(syncKeyMaterial),
+    kty: "oct",
+  }
+}
+
+export async function encryptKeysJWE(
+  scopedKeysBundle: Record<string, ScopedKeyJWK>,
+  keysJwkB64: string
+): Promise<string> {
+  // Decode the base64url-encoded JWK from Firefox
+  const jwkJson = new TextDecoder().decode(
+    Uint8Array.from(atob(keysJwkB64.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
+      c.charCodeAt(0)
+    )
+  )
+  const jwk = JSON.parse(jwkJson)
+
+  // Import the EC P-256 public key
+  const publicKey = await importJWK(jwk, "ECDH-ES")
+
+  // Encrypt the scoped keys bundle as a JWE
+  const payload = new TextEncoder().encode(JSON.stringify(scopedKeysBundle))
+  const jwe = await new CompactEncrypt(payload)
+    .setProtectedHeader({ alg: "ECDH-ES", enc: "A256GCM", kid: jwk.kid })
+    .encrypt(publicKey)
+
+  return jwe
+}
+
+export async function deriveAndEncryptSyncKeys(
+  params: DeriveAndEncryptParams
+): Promise<string> {
+  const {
+    authServerUrl,
+    keyFetchTokenHex,
+    unwrapBKeyHex,
+    sessionTokenHex,
+    keysJwkB64,
+    scope,
+  } = params
+
+  // 1. Fetch the encrypted key bundle from the server
+  const bundleHex = await fetchAccountKeys(authServerUrl, keyFetchTokenHex)
+
+  // 2. Decrypt the key bundle
+  const { wrapKB } = await decryptKeyBundle(keyFetchTokenHex, bundleHex)
+
+  // 3. Derive kB by XOR-ing wrapKB with unwrapBKey
+  const kBHex = deriveKB(wrapKB, unwrapBKeyHex)
+
+  // 4. Fetch scoped key metadata
+  const scopedKeyData = await fetchScopedKeyData(
+    authServerUrl,
+    sessionTokenHex,
+    scope.split(" ")[0],
+    scope
+  )
+
+  // 5. Derive scoped sync key
+  const syncScope = "https://identity.mozilla.com/apps/oldsync"
+  const metadata = scopedKeyData[syncScope]
+  if (!metadata) {
+    throw new Error(`No scoped key data returned for ${syncScope}`)
+  }
+
+  const scopedKey = await deriveScopedSyncKey(kBHex, metadata.keyRotationTimestamp)
+
+  // 6. Encrypt as JWE for Firefox
+  const keysBundle: Record<string, ScopedKeyJWK> = {
+    [syncScope]: scopedKey,
+  }
+  return encryptKeysJWE(keysBundle, keysJwkB64)
+}

--- a/lambda/src/routes/auth/oauth_authorization.py
+++ b/lambda/src/routes/auth/oauth_authorization.py
@@ -64,6 +64,7 @@ class OAuthAuthorizationRoute(BaseRoute):
 
         code_challenge = body.get("code_challenge", "")
         code_challenge_method = body.get("code_challenge_method", "S256")
+        keys_jwe = body.get("keys_jwe", "")
 
         code = self._oauth_code_manager.create_authorization_code(
             uid=uid,
@@ -71,6 +72,7 @@ class OAuthAuthorizationRoute(BaseRoute):
             scope=scope,
             code_challenge=code_challenge,
             code_challenge_method=code_challenge_method,
+            keys_jwe=keys_jwe,
         )
 
         return Response(

--- a/lambda/src/routes/auth/oauth_token.py
+++ b/lambda/src/routes/auth/oauth_token.py
@@ -104,19 +104,23 @@ class OAuthTokenRoute(BaseRoute):
             scope=scope,
         )
 
+        response_body: dict = {
+            "access_token": access_token,
+            "token_type": "bearer",
+            "expires_in": ttl,
+            "scope": scope,
+            "refresh_token": refresh_token,
+            "auth_at": int(time.time()),
+        }
+
+        keys_jwe = code_data.get("keysJwe", "")
+        if keys_jwe:
+            response_body["keys_jwe"] = keys_jwe
+
         return Response(
             status_code=200,
             content_type="application/json",
-            body=json.dumps(
-                {
-                    "access_token": access_token,
-                    "token_type": "bearer",
-                    "expires_in": ttl,
-                    "scope": scope,
-                    "refresh_token": refresh_token,
-                    "auth_at": int(time.time()),
-                }
-            ),
+            body=json.dumps(response_body),
         )
 
     def _handle_refresh_token(self, body: dict) -> Response:

--- a/lambda/src/services/oauth_code_manager.py
+++ b/lambda/src/services/oauth_code_manager.py
@@ -34,6 +34,7 @@ class OAuthCodeManager:
         scope: str,
         code_challenge: str,
         code_challenge_method: str,
+        keys_jwe: str = "",
     ) -> str:
         """Create an authorization code and store in DynamoDB.
 
@@ -51,6 +52,7 @@ class OAuthCodeManager:
                 "scope": scope,
                 "codeChallenge": code_challenge,
                 "codeChallengeMethod": code_challenge_method,
+                "keysJwe": keys_jwe,
                 "expiry": now + self._code_ttl,
             }
         )
@@ -90,6 +92,7 @@ class OAuthCodeManager:
             "scope": item["scope"],
             "codeChallenge": item["codeChallenge"],
             "codeChallengeMethod": item["codeChallengeMethod"],
+            "keysJwe": item.get("keysJwe", ""),
         }
 
     def create_refresh_token(self, uid: str, client_id: str, scope: str) -> str:

--- a/lambda/tests/routes/auth/test_oauth_authorization.py
+++ b/lambda/tests/routes/auth/test_oauth_authorization.py
@@ -192,6 +192,40 @@ class TestOAuthAuthorization:
             scope="openid",
             code_challenge="ch",
             code_challenge_method="S256",
+            keys_jwe="",
+        )
+
+    def test_passes_keys_jwe_to_code_manager(
+        self, route, mock_token_manager, mock_oauth_code_manager
+    ):
+        mock_token_manager.verify_session_hawk.return_value = "uid1"
+        mock_oauth_code_manager.create_authorization_code.return_value = "code"
+
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "POST",
+                "path": "/v1/oauth/authorization",
+                "headers": {"authorization": 'Hawk id="tok"'},
+                "body": json.dumps(
+                    {
+                        "client_id": "client1",
+                        "scope": "openid",
+                        "state": "st",
+                        "code_challenge": "ch",
+                        "code_challenge_method": "S256",
+                        "keys_jwe": "encrypted-jwe-payload",
+                    }
+                ),
+            }
+        )
+        route.handle(event)
+        mock_oauth_code_manager.create_authorization_code.assert_called_once_with(
+            uid="uid1",
+            client_id="client1",
+            scope="openid",
+            code_challenge="ch",
+            code_challenge_method="S256",
+            keys_jwe="encrypted-jwe-payload",
         )
 
 

--- a/lambda/tests/routes/auth/test_oauth_token.py
+++ b/lambda/tests/routes/auth/test_oauth_token.py
@@ -52,6 +52,7 @@ class TestOAuthTokenAuthorizationCode:
             "scope": "https://identity.mozilla.com/apps/oldsync",
             "codeChallenge": "challenge",
             "codeChallengeMethod": "S256",
+            "keysJwe": "some-jwe",
         }
         mock_jwt_service.sign_jwt.return_value = "jwt-access-token"
         mock_oauth_code_manager.create_refresh_token.return_value = "refresh-tok"
@@ -83,6 +84,54 @@ class TestOAuthTokenAuthorizationCode:
         assert body["token_type"] == "bearer"
         assert "expires_in" in body
         assert body["scope"] == "https://identity.mozilla.com/apps/oldsync"
+        assert body["keys_jwe"] == "some-jwe"
+
+    @patch(
+        "src.routes.auth.oauth_token.OAuthCodeManager.verify_code_challenge",
+        return_value=True,
+    )
+    def test_omits_keys_jwe_when_empty(
+        self,
+        mock_verify,
+        route,
+        mock_oauth_code_manager,
+        mock_jwt_service,
+        mock_account_manager,
+    ):
+        mock_oauth_code_manager.consume_authorization_code.return_value = {
+            "uid": "uid1",
+            "clientId": "client1",
+            "scope": "openid",
+            "codeChallenge": "challenge",
+            "codeChallengeMethod": "S256",
+            "keysJwe": "",
+        }
+        mock_jwt_service.sign_jwt.return_value = "jwt"
+        mock_oauth_code_manager.create_refresh_token.return_value = "refresh"
+        mock_account_manager.get_account_by_uid.return_value = {
+            "uid": "uid1",
+            "oidcSub": "sub1",
+        }
+
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "POST",
+                "path": "/v1/oauth/token",
+                "headers": {},
+                "body": json.dumps(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": "code",
+                        "code_verifier": "verifier",
+                        "client_id": "client1",
+                    }
+                ),
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert "keys_jwe" not in body
 
     def test_invalid_code_returns_400(self, route, mock_oauth_code_manager):
         mock_oauth_code_manager.consume_authorization_code.return_value = None

--- a/lambda/tests/services/test_oauth_code_manager.py
+++ b/lambda/tests/services/test_oauth_code_manager.py
@@ -47,7 +47,21 @@ class TestCreateAuthorizationCode:
         assert item["scope"] == "openid"
         assert item["codeChallenge"] == "challenge123"
         assert item["codeChallengeMethod"] == "S256"
+        assert item["keysJwe"] == ""
         assert "expiry" in item
+
+    def test_stores_keys_jwe_in_dynamo(self, manager, mock_table):
+        manager.create_authorization_code(
+            uid="uid1",
+            client_id="client1",
+            scope="openid",
+            code_challenge="challenge123",
+            code_challenge_method="S256",
+            keys_jwe="some-jwe-value",
+        )
+        mock_table.put_item.assert_called_once()
+        item = mock_table.put_item.call_args.kwargs["Item"]
+        assert item["keysJwe"] == "some-jwe-value"
 
     def test_different_calls_produce_different_codes(self, manager):
         code1 = manager.create_authorization_code(
@@ -79,6 +93,7 @@ class TestConsumeAuthorizationCode:
                 "scope": "openid",
                 "codeChallenge": "challenge",
                 "codeChallengeMethod": "S256",
+                "keysJwe": "jwe-value",
                 "expiry": 1000600,
             }
         }
@@ -88,11 +103,30 @@ class TestConsumeAuthorizationCode:
         assert result["clientId"] == "client1"
         assert result["scope"] == "openid"
         assert result["codeChallenge"] == "challenge"
+        assert result["keysJwe"] == "jwe-value"
         mock_table.delete_item.assert_called_once()
         # Verify it's called with ReturnValues and ConditionExpression
         call_kwargs = mock_table.delete_item.call_args.kwargs
         assert call_kwargs["ReturnValues"] == "ALL_OLD"
         assert call_kwargs["ConditionExpression"] == "attribute_exists(PK)"
+
+    @patch("src.services.oauth_code_manager.time")
+    def test_returns_empty_keys_jwe_when_missing(self, mock_time, manager, mock_table):
+        mock_time.time.return_value = 1000000.0
+        mock_table.delete_item.return_value = {
+            "Attributes": {
+                "PK": "OAUTHCODE#abc123",
+                "uid": "uid1",
+                "clientId": "client1",
+                "scope": "openid",
+                "codeChallenge": "challenge",
+                "codeChallengeMethod": "S256",
+                "expiry": 1000600,
+            }
+        }
+        result = manager.consume_authorization_code("abc123")
+        assert result is not None
+        assert result["keysJwe"] == ""
 
     def test_returns_none_for_unknown_code(self, manager, mock_table):
         mock_table.delete_item.side_effect = ClientError(


### PR DESCRIPTION
## Summary

- Implement the full client-side key derivation pipeline so Firefox receives `keys_jwe` in the `/v1/oauth/token` response and shows as "connected" with sync enabled
- Add `sync-keys.ts` module: fetches encrypted key bundle, decrypts it, derives kB, computes scoped sync key, encrypts as JWE using Firefox's ephemeral EC P-256 public key (`keys_jwk`)
- Plumb `keys_jwe` through the backend OAuth flow (authorization code creation, storage, token response)

## Changes

**Frontend:**
- Add `jose` dependency for ECDH-ES + A256GCM JWE encryption
- Generalize `buildHawkHeader` into `buildHawkHeaderWithInfo`, export `hkdf`/`hexToBytes`/`toHex` from `fxa-crypto.ts`
- Export `authFetch`, add optional `keysJwe` param to `requestOAuthCode` in `auth-client.ts`
- New `sync-keys.ts`: `fetchAccountKeys`, `decryptKeyBundle`, `deriveKB`, `fetchScopedKeyData`, `deriveScopedSyncKey`, `encryptKeysJWE`, `deriveAndEncryptSyncKeys`
- Parse `keys_jwk` from query params in `App.tsx`, restore after OIDC redirect
- Wire key exchange in `SignInPage.tsx`, remove void statements for `keyFetchToken`/`unwrapBKey`

**Backend:**
- `oauth_code_manager.py`: store/return `keysJwe` field
- `oauth_authorization.py`: accept `keys_jwe` from request body
- `oauth_token.py`: return `keys_jwe` in token response (authorization_code grant only, omitted when empty)

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc -b --noEmit`)
- [x] 906 Lambda tests pass with 100% code coverage
- [ ] End-to-end: sign in via Firefox -> Firefox shows as connected with sync enabled