### PR TITLE
fix: handle DynamoDB Decimal in scoped-key-data JSON response

### DIFF
--- a/lambda/src/routes/auth/scoped_key_data.py
+++ b/lambda/src/routes/auth/scoped_key_data.py
@@ -7,6 +7,7 @@ from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
 from src.services.auth_account_manager import AuthAccountManager
 from src.services.fxa_token_manager import FxATokenManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import json_dumps
 
 
 class ScopedKeyDataRoute(BaseRoute):
@@ -75,7 +76,7 @@ class ScopedKeyDataRoute(BaseRoute):
         return Response(
             status_code=200,
             content_type="application/json",
-            body=json.dumps(result),
+            body=json_dumps(result),
         )
 
     @staticmethod

--- a/lambda/tests/routes/auth/test_scoped_key_data.py
+++ b/lambda/tests/routes/auth/test_scoped_key_data.py
@@ -1,6 +1,7 @@
 """Unit tests for ScopedKeyData route"""
 
 import json
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
@@ -121,6 +122,34 @@ class TestScopedKeyData:
         )
         response = route.handle(event)
         assert response.status_code == 401
+
+    def test_handles_decimal_created_at_from_dynamodb(
+        self, route, mock_token_manager, mock_account_manager
+    ):
+        mock_token_manager.verify_session_hawk.return_value = "uid1"
+        mock_account_manager.get_account_by_uid.return_value = {
+            "uid": "uid1",
+            "createdAt": Decimal("1234567890"),
+            "keyRotationSecret": "ab" * 32,
+        }
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "POST",
+                "path": "/v1/account/scoped-key-data",
+                "headers": {"authorization": 'Hawk id="tokenid"'},
+                "body": json.dumps(
+                    {
+                        "client_id": "client1",
+                        "scope": "https://identity.mozilla.com/apps/oldsync",
+                    }
+                ),
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        scope_key = "https://identity.mozilla.com/apps/oldsync"
+        assert body[scope_key]["keyRotationTimestamp"] == 1234567890.0
 
     def test_missing_scope_returns_400(self, route, mock_token_manager):
         mock_token_manager.verify_session_hawk.return_value = "uid1"


### PR DESCRIPTION
## Summary

- Fix `TypeError: Object of type Decimal is not JSON serializable` in `/v1/account/scoped-key-data`
- DynamoDB returns `createdAt` as a `Decimal`, which `json.dumps` cannot serialize
- Replace `json.dumps` with the project's existing `json_dumps` helper (`DecimalEncoder`) in `scoped_key_data.py`
- Add regression test using `Decimal` values to match real DynamoDB behavior

## Test plan

- [x] 907 tests pass, 100% coverage
- [ ] Deploy and verify `/v1/account/scoped-key-data` returns valid JSON