### PR TITLE
fix: send fxaccounts:login before oauth_login for Desktop Firefox

### DIFF
--- a/frontend/src/components/SignInPage.tsx
+++ b/frontend/src/components/SignInPage.tsx
@@ -27,7 +27,9 @@ import {
 } from "@/lib/auth-client"
 import {
   listenFromFirefox,
+  sendCanLinkAccount,
   sendFxAStatus,
+  sendLogin,
   sendOAuthLogin,
 } from "@/lib/webchannel"
 import { generatePKCE } from "@/lib/pkce"
@@ -68,6 +70,15 @@ export function SignInPage({
   const [passwordLoading, setPasswordLoading] = useState(false)
   const initialized = useRef(false)
 
+  const syncEngines = [
+    "bookmarks",
+    "history",
+    "passwords",
+    "tabs",
+    "prefs",
+    "addons",
+  ]
+
   const handleError = useCallback((msg: string) => {
     console.error(`[ffsync] FxA sign-in error: ${msg}`)
     setSignInState({ step: "error", message: msg })
@@ -82,17 +93,12 @@ export function SignInPage({
         sendFxAStatus(
           {
             choose_what_to_sync: true,
-            engines: [
-              "bookmarks",
-              "history",
-              "passwords",
-              "tabs",
-              "prefs",
-              "addons",
-            ],
+            engines: syncEngines,
           },
           messageId
         )
+      } else if (command === "fxaccounts:can_link_account") {
+        sendCanLinkAccount(true, messageId)
       }
     })
 
@@ -245,9 +251,24 @@ export function SignInPage({
         message: "Completing sign-in...",
       })
 
-      sendOAuthLogin(oauthResult.code, oauthResult.state)
+      // Send fxaccounts:login first so Firefox stores the account data
+      // (uid, sessionToken, etc.) that oauthLogin reads back.
+      sendLogin({
+        email,
+        uid,
+        sessionToken,
+        keyFetchToken,
+        unwrapBKey,
+        verified: true,
+        declinedSyncEngines: [],
+        offeredSyncEngines: syncEngines,
+        verifiedCanLinkAccount: true,
+      })
 
-      void uid
+      // Then send fxaccounts:oauth_login so Firefox exchanges the code
+      // at /v1/oauth/token and receives keys_jwe with the scoped sync keys.
+      sendOAuthLogin(oauthResult.code, oauthResult.state, [], syncEngines)
+
       void codeVerifier
       void service
       void action

--- a/frontend/src/lib/webchannel.ts
+++ b/frontend/src/lib/webchannel.ts
@@ -43,17 +43,48 @@ export function listenFromFirefox(
   return () => window.removeEventListener("WebChannelMessageToContent", handler)
 }
 
+export interface LoginData {
+  email: string
+  uid: string
+  sessionToken: string
+  keyFetchToken: string
+  unwrapBKey: string
+  verified: boolean
+  declinedSyncEngines: string[]
+  offeredSyncEngines: string[]
+  verifiedCanLinkAccount: boolean
+}
+
+export function sendLogin(data: LoginData): void {
+  sendToFirefox("fxaccounts:login", {
+    ...data,
+    services: {
+      sync: {},
+    },
+  })
+}
+
 export function sendOAuthLogin(
   code: string,
   state: string,
-  declinedSyncEngines: string[] = []
+  declinedSyncEngines: string[] = [],
+  offeredSyncEngines: string[] = []
 ): void {
   sendToFirefox("fxaccounts:oauth_login", {
     code,
     state,
     redirect: "urn:ietf:wg:oauth:2.0:oob",
+    action: "signin",
     declinedSyncEngines,
+    offeredSyncEngines,
   })
+}
+
+export function sendCanLinkAccount(
+  ok: boolean,
+  messageId?: string
+): void {
+  sendToFirefox("fxaccounts:can_link_account", { ok }, messageId)
 }
 
 export function sendFxAStatus(


### PR DESCRIPTION
## Summary

- Fix Firefox Desktop not showing as "connected" after completing the sign-in flow
- Desktop Firefox expects **two** webchannel messages in sequence:
  1. `fxaccounts:login` — stores account data (email, uid, sessionToken, keyFetchToken, unwrapBKey) via `setSignedInUser()`
  2. `fxaccounts:oauth_login` — triggers `completeOAuthFlow()` which reads back the stored sessionToken, exchanges the OAuth code at `/v1/oauth/token`, and decrypts `keys_jwe`
- Without the preceding `fxaccounts:login`, Firefox's `oauthLogin()` calls `getUserAccountData()` and gets nothing back, failing silently
- Also handle `fxaccounts:can_link_account` webchannel message (respond with `{ ok: true }`)

## Changes

**`webchannel.ts`:**
- Add `sendLogin()` for `fxaccounts:login` with full loginData (email, uid, sessionToken, keyFetchToken, unwrapBKey, verified, engines)
- Add `sendCanLinkAccount()` for `fxaccounts:can_link_account` response
- Add `offeredSyncEngines` and `action` to `sendOAuthLogin()`

**`SignInPage.tsx`:**
- Handle `fxaccounts:can_link_account` in webchannel listener
- Send `fxaccounts:login` before `fxaccounts:oauth_login` in `handlePasswordSubmit`
- Lift `syncEngines` to component scope (shared between listener and submit handler)
- Remove `void uid`, `void keyFetchToken`, `void unwrapBKey` (now used in `sendLogin`)

## Test plan

- [x] TypeScript compiles cleanly
- [ ] Deploy and sign in via Firefox Desktop — Firefox should show as connected with sync enabled