### PR TITLE
fix: restore all Firefox query params after OIDC redirect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -206,25 +206,26 @@ function FxAFlow() {
 
   // After OIDC redirect, original Firefox params are lost from the URL.
   // Restore from session storage (stored before OIDC redirect in SignInPage).
+  // All FxA params (state, code_challenge, keys_jwk, etc.) must be restored
+  // so Firefox can match the OAuth flow it started in beginOAuthFlow().
   const storedFxAParams = session.getFxAParams()
   const fxaParams = storedFxAParams
     ? new URLSearchParams(storedFxAParams)
     : searchParams
-  const keysJwk = fxaParams.get("keys_jwk") ?? undefined
 
   return (
     <SignInPage
       config={config}
-      action={searchParams.get("action") ?? "signin"}
-      service={searchParams.get("service") ?? undefined}
-      state={searchParams.get("state") ?? undefined}
-      codeChallenge={searchParams.get("code_challenge") ?? undefined}
-      clientId={searchParams.get("client_id") ?? config.clientId}
+      action={fxaParams.get("action") ?? "signin"}
+      service={fxaParams.get("service") ?? undefined}
+      state={fxaParams.get("state") ?? undefined}
+      codeChallenge={fxaParams.get("code_challenge") ?? undefined}
+      clientId={fxaParams.get("client_id") ?? config.clientId}
       scope={
-        searchParams.get("scope") ??
+        fxaParams.get("scope") ??
         "https://identity.mozilla.com/apps/oldsync profile"
       }
-      keysJwk={keysJwk}
+      keysJwk={fxaParams.get("keys_jwk") ?? undefined}
     />
   )
 }


### PR DESCRIPTION
## Summary

After the OIDC redirect round-trip, Firefox's original query params (`state`, `code_challenge`, `client_id`, `scope`, `keys_jwk`) are lost from the URL. Only `keys_jwk` was being restored from session storage; the rest were read from the now-empty URL search params.

This caused `state` and `code_challenge` mismatches: the frontend generated new values that didn't match what Firefox stored in `beginOAuthFlow()`. When Firefox called `completeOAuthFlow(code, state)`, it couldn't find the matching flow (private key + PKCE verifier), so the token exchange failed — resulting in the "finish account setup" prompt.

## Changes

**`App.tsx`:** Read all FxA params (`action`, `service`, `state`, `code_challenge`, `client_id`, `scope`, `keys_jwk`) from the restored session storage (`fxaParams`) instead of `searchParams`.

## Test plan

- [x] TypeScript compiles cleanly
- [ ] Deploy and complete sign-in via Firefox Desktop — should fully connect without "finish account setup" prompt