### PR TITLE
fix: add /1.5/{uid} path prefix to storage API routes

### DIFF
--- a/lambda/src/routes/bso/delete.py
+++ b/lambda/src/routes/bso/delete.py
@@ -19,8 +19,8 @@ class DeleteBSORoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.delete("/storage/<collectionName>/<objectId>")
-        def handle_request(collectionName: str, objectId: str):
+        @app.delete("/1.5/<uid>/storage/<collectionName>/<objectId>")
+        def handle_request(uid: str, collectionName: str, objectId: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/bso/read.py
+++ b/lambda/src/routes/bso/read.py
@@ -19,8 +19,8 @@ class ReadBSORoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.get("/storage/<collectionName>/<objectId>")
-        def handle_request(collectionName: str, objectId: str):
+        @app.get("/1.5/<uid>/storage/<collectionName>/<objectId>")
+        def handle_request(uid: str, collectionName: str, objectId: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/bso/update.py
+++ b/lambda/src/routes/bso/update.py
@@ -33,8 +33,8 @@ class UpdateBSORoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.put("/storage/<collectionName>/<objectId>")
-        def handle_request(collectionName: str, objectId: str):
+        @app.put("/1.5/<uid>/storage/<collectionName>/<objectId>")
+        def handle_request(uid: str, collectionName: str, objectId: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/collections/create.py
+++ b/lambda/src/routes/collections/create.py
@@ -24,8 +24,8 @@ class CreateCollectionRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.post("/storage/<collectionName>")
-        def handle_request(collectionName: str):
+        @app.post("/1.5/<uid>/storage/<collectionName>")
+        def handle_request(uid: str, collectionName: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/collections/delete.py
+++ b/lambda/src/routes/collections/delete.py
@@ -15,8 +15,8 @@ class DeleteCollectionRoute(BaseRoute):
         self.dynamodb_service = dynamodb_service
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.delete("/storage/<collectionName>")
-        def handle_request(collectionName: str):
+        @app.delete("/1.5/<uid>/storage/<collectionName>")
+        def handle_request(uid: str, collectionName: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/collections/list.py
+++ b/lambda/src/routes/collections/list.py
@@ -13,8 +13,8 @@ class ListCollectionsRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.get("/storage")
-        def handle_request():
+        @app.get("/1.5/<uid>/storage")
+        def handle_request(uid: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/collections/read.py
+++ b/lambda/src/routes/collections/read.py
@@ -15,8 +15,8 @@ class ReadCollectionRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.get("/storage/<collectionName>")
-        def handle_request(collectionName: str):
+        @app.get("/1.5/<uid>/storage/<collectionName>")
+        def handle_request(uid: str, collectionName: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/collections/update.py
+++ b/lambda/src/routes/collections/update.py
@@ -22,8 +22,8 @@ class UpdateCollectionRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.put("/storage/<collectionName>")
-        def handle_request(collectionName: str):
+        @app.put("/1.5/<uid>/storage/<collectionName>")
+        def handle_request(uid: str, collectionName: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/info/read_collections.py
+++ b/lambda/src/routes/info/read_collections.py
@@ -13,8 +13,8 @@ class ReadCollectionsInfoRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.get("/info/collections")
-        def handle_request():
+        @app.get("/1.5/<uid>/info/collections")
+        def handle_request(uid: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/info/read_configuration.py
+++ b/lambda/src/routes/info/read_configuration.py
@@ -34,8 +34,8 @@ class ReadConfigurationRoute(BaseRoute):
         self.max_total_bytes = max_total_bytes
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.get("/info/configuration")
-        def handle_request():
+        @app.get("/1.5/<uid>/info/configuration")
+        def handle_request(uid: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/info/read_counts.py
+++ b/lambda/src/routes/info/read_counts.py
@@ -13,8 +13,8 @@ class ReadCollectionCountsRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.get("/info/collection_counts")
-        def handle_request():
+        @app.get("/1.5/<uid>/info/collection_counts")
+        def handle_request(uid: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/info/read_quota.py
+++ b/lambda/src/routes/info/read_quota.py
@@ -17,8 +17,8 @@ class ReadQuotaInfoRoute(BaseRoute):
         self.quota_kb = quota_kb
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.get("/info/quota")
-        def handle_request():
+        @app.get("/1.5/<uid>/info/quota")
+        def handle_request(uid: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/info/read_usage.py
+++ b/lambda/src/routes/info/read_usage.py
@@ -13,8 +13,8 @@ class ReadCollectionUsageRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.get("/info/collection_usage")
-        def handle_request():
+        @app.get("/1.5/<uid>/info/collection_usage")
+        def handle_request(uid: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/storage/delete_all.py
+++ b/lambda/src/routes/storage/delete_all.py
@@ -13,8 +13,8 @@ class DeleteAllStorageRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.delete("/storage")
-        def handle_request():
+        @app.delete("/1.5/<uid>/storage")
+        def handle_request(uid: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/src/routes/storage/delete_root.py
+++ b/lambda/src/routes/storage/delete_root.py
@@ -13,8 +13,8 @@ class DeleteAllRootRoute(BaseRoute):
         self.storage_manager = storage_manager
 
     def bind(self, app: APIGatewayRestResolver):
-        @app.delete("/")
-        def handle_request():
+        @app.delete("/1.5/<uid>")
+        def handle_request(uid: str):
             return self.handle(app.current_event)
 
     def handle(self, event) -> Response:

--- a/lambda/tests/conftest.py
+++ b/lambda/tests/conftest.py
@@ -142,8 +142,9 @@ def sample_lambda_event(test_user_id):
     """Sample Lambda event structure"""
     return {
         "httpMethod": "GET",
-        "path": "/storage/test_collection/test_object",
+        "path": "/1.5/12345/storage/test_collection/test_object",
         "pathParameters": {
+            "uid": "12345",
             "collectionName": "test_collection",
             "objectId": "test_object",
         },
@@ -210,8 +211,8 @@ def post_event_with_body():
     """Sample POST event with body"""
     return {
         "httpMethod": "POST",
-        "path": "/storage/test_collection",
-        "pathParameters": {"collectionName": "test_collection"},
+        "path": "/1.5/12345/storage/test_collection",
+        "pathParameters": {"uid": "12345", "collectionName": "test_collection"},
         "headers": {"Content-Type": "application/json"},
         "body": json.dumps({"objects": [{"id": "obj1", "payload": "data1", "sortindex": 100}]}),
         "queryStringParameters": None,
@@ -223,8 +224,9 @@ def delete_event():
     """Sample DELETE event"""
     return {
         "httpMethod": "DELETE",
-        "path": "/storage/test_collection/test_object",
+        "path": "/1.5/12345/storage/test_collection/test_object",
         "pathParameters": {
+            "uid": "12345",
             "collectionName": "test_collection",
             "objectId": "test_object",
         },

--- a/lambda/tests/entrypoint/test_hawk_authorizer.py
+++ b/lambda/tests/entrypoint/test_hawk_authorizer.py
@@ -38,14 +38,14 @@ def authorizer_event(valid_hawk_id, current_timestamp):
         "methodArn": "arn:aws:execute-api:us-east-1:123456789012:abcdef123/prod/GET/storage/bookmarks",
         "identitySource": "",
         "authorizationToken": "",
-        "resource": "/storage/bookmarks",
-        "path": "/storage/bookmarks",
+        "resource": "/1.5/12345/storage/bookmarks",
+        "path": "/1.5/12345/storage/bookmarks",
         "httpMethod": "GET",
         "headers": {
             "Authorization": f'Hawk id="{valid_hawk_id}", ts="{current_timestamp}", nonce="abc123", mac="test_mac"'
         },
         "queryStringParameters": {},
-        "pathParameters": {},
+        "pathParameters": {"uid": "12345"},
         "stageVariables": {},
         "requestContext": {
             "domainName": "api.example.com",

--- a/lambda/tests/entrypoint/test_storage_api.py
+++ b/lambda/tests/entrypoint/test_storage_api.py
@@ -32,8 +32,8 @@ def test_storage_api_happ_path(mock_service_provider, dynamodb_stubber, sample_l
 
     event = {
         "httpMethod": "GET",
-        "path": "/storage/bookmarks/item123",
-        "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+        "path": "/1.5/12345/storage/bookmarks/item123",
+        "pathParameters": {"uid": "12345", "collectionName": "bookmarks", "objectId": "item123"},
         "headers": {},
         "body": None,
         "queryStringParameters": None,

--- a/lambda/tests/fixtures/integration.py
+++ b/lambda/tests/fixtures/integration.py
@@ -171,10 +171,14 @@ def build_storage_event(
     if body is not None and isinstance(body, (dict, list)):
         body = json.dumps(body)
 
+    merged_params = {"uid": "12345"}
+    if path_params:
+        merged_params.update(path_params)
+
     return {
         "httpMethod": method,
-        "path": path,
-        "pathParameters": path_params or {},
+        "path": f"/1.5/12345{path}",
+        "pathParameters": merged_params,
         "headers": headers,
         "body": body,
         "queryStringParameters": query_params,

--- a/lambda/tests/integration/test_e2e_flow.py
+++ b/lambda/tests/integration/test_e2e_flow.py
@@ -51,7 +51,7 @@ class TestHawkAuthorizerToStorageAPIFlow:
         timestamp = int(time.time())
         nonce = "test-nonce-123"
         method = "GET"
-        path = "/storage/bookmarks"
+        path = "/1.5/12345/storage/bookmarks"
         host = "storage.sync.example.com"
         port = 443
 
@@ -173,7 +173,7 @@ class TestHawkAuthorizerToStorageAPIFlow:
         timestamp = int(time.time())
         nonce = "test-nonce-123"
         method = "GET"
-        path = "/storage/bookmarks"
+        path = "/1.5/12345/storage/bookmarks"
         host = "storage.sync.example.com"
         port = 443
 
@@ -225,7 +225,7 @@ class TestHawkAuthorizerToStorageAPIFlow:
             "type": "REQUEST",
             "methodArn": "arn:aws:execute-api:us-east-1:123456789012:abcdef123/prod/GET/storage",
             "headers": {"Host": "storage.sync.example.com"},
-            "requestContext": {"path": "/storage/bookmarks", "httpMethod": "GET"},
+            "requestContext": {"path": "/1.5/12345/storage/bookmarks", "httpMethod": "GET"},
         }
 
         # Authorizer should reject missing header

--- a/lambda/tests/integration/test_token_to_storage_flow.py
+++ b/lambda/tests/integration/test_token_to_storage_flow.py
@@ -152,7 +152,7 @@ class TestTokenServerToStorageServerFlow:
         timestamp = int(time.time())
         nonce = "test-nonce-integration"
         method = "GET"
-        path = "/storage/bookmarks"
+        path = "/1.5/12345/storage/bookmarks"
         host = "storage.sync.example.com"
         port = 443
 
@@ -414,7 +414,7 @@ class TestTokenServerToStorageServerFlow:
         timestamp = int(time.time())
         nonce = "test-nonce-expired"
         method = "GET"
-        path = "/storage/bookmarks"
+        path = "/1.5/12345/storage/bookmarks"
         host = "storage.sync.example.com"
         port = 443
 
@@ -481,7 +481,7 @@ class TestTokenServerToStorageServerFlow:
         timestamp = int(time.time())
         nonce = "test-nonce-invalid"
         method = "GET"
-        path = "/storage/bookmarks"
+        path = "/1.5/12345/storage/bookmarks"
 
         # Use wrong MAC (not computed from the request)
         invalid_mac = "invalid-mac-signature"
@@ -549,7 +549,7 @@ class TestTokenServerToStorageServerFlow:
         timestamp = int(time.time())
         nonce = "test-nonce-gen"
         method = "GET"
-        path = "/storage/bookmarks"
+        path = "/1.5/12345/storage/bookmarks"
 
         normalized = hawk_service.build_normalized_string(
             str(timestamp), nonce, method, path, "storage.sync.example.com", "443"

--- a/lambda/tests/routes/storage/test_delete_root.py
+++ b/lambda/tests/routes/storage/test_delete_root.py
@@ -12,8 +12,8 @@ def build_storage_event(method: str, path: str, user_id: str = TEST_USER_ID) -> 
     """Build a storage API event with authentication context"""
     return {
         "httpMethod": method,
-        "path": path,
-        "pathParameters": None,
+        "path": f"/1.5/12345{path}",
+        "pathParameters": {"uid": "12345"},
         "headers": {},
         "body": None,
         "queryStringParameters": None,
@@ -109,8 +109,8 @@ class TestDeleteAllRootRoute:
         """Test handling when user_id is missing from authorizer context"""
         event: dict[str, Any] = {
             "httpMethod": "DELETE",
-            "path": "/",
-            "pathParameters": None,
+            "path": "/1.5/12345",
+            "pathParameters": {"uid": "12345"},
             "headers": {},
             "body": None,
             "queryStringParameters": None,

--- a/lambda/tests/routes/test_bso_routes.py
+++ b/lambda/tests/routes/test_bso_routes.py
@@ -41,8 +41,12 @@ class TestReadBSORoute:
         # Test through the resolver
         event = {
             "httpMethod": "GET",
-            "path": "/storage/bookmarks/item123",
-            "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+            "path": "/1.5/12345/storage/bookmarks/item123",
+            "pathParameters": {
+                "uid": "12345",
+                "collectionName": "bookmarks",
+                "objectId": "item123",
+            },
             "headers": {},
             "body": None,
             "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -56,7 +60,11 @@ class TestReadBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -93,7 +101,11 @@ class TestReadBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "history", "objectId": "obj456"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "history",
+                    "objectId": "obj456",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -121,7 +133,11 @@ class TestReadBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "invalid!@#", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "invalid!@#",
+                    "objectId": "item",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -143,7 +159,11 @@ class TestReadBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "nonexistent", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "nonexistent",
+                    "objectId": "item",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -165,7 +185,11 @@ class TestReadBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "nonexistent"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "nonexistent",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -187,7 +211,11 @@ class TestReadBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -222,8 +250,12 @@ class TestUpdateBSORoute:
 
         event = {
             "httpMethod": "PUT",
-            "path": "/storage/bookmarks/item123",
-            "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+            "path": "/1.5/12345/storage/bookmarks/item123",
+            "pathParameters": {
+                "uid": "12345",
+                "collectionName": "bookmarks",
+                "objectId": "item123",
+            },
             "headers": {},
             "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
             "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -237,7 +269,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps(
                     {
                         "object": {
@@ -276,7 +312,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item",
+                },
                 "body": "invalid json{",
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -293,7 +333,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item",
+                },
                 "body": json.dumps({"payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -310,7 +354,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "different_id", "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -327,7 +375,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
                 "headers": {"X-If-Unmodified-Since": "1234567890"},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -353,7 +405,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
                 "headers": {"X-If-Unmodified-Since": "invalid"},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -370,7 +426,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "nonexistent", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "nonexistent",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -391,7 +451,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "nonexistent"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "nonexistent",
+                },
                 "body": json.dumps({"object": {"id": "nonexistent", "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -412,7 +476,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -433,7 +501,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "invalid!", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "invalid!",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -452,7 +524,11 @@ class TestUpdateBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item",
+                },
                 "body": json.dumps({"object": {"id": "item", "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -478,8 +554,12 @@ class TestDeleteBSORoute:
 
         event = {
             "httpMethod": "DELETE",
-            "path": "/storage/bookmarks/item123",
-            "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+            "path": "/1.5/12345/storage/bookmarks/item123",
+            "pathParameters": {
+                "uid": "12345",
+                "collectionName": "bookmarks",
+                "objectId": "item123",
+            },
             "headers": {},
             "body": None,
             "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -493,7 +573,11 @@ class TestDeleteBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -516,7 +600,11 @@ class TestDeleteBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "invalid!", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "invalid!",
+                    "objectId": "item",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -533,7 +621,11 @@ class TestDeleteBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "nonexistent", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "nonexistent",
+                    "objectId": "item",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -552,7 +644,11 @@ class TestDeleteBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "nonexistent"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "nonexistent",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -571,7 +667,11 @@ class TestDeleteBSORoute:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item",
+                },
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
         )
@@ -592,7 +692,11 @@ class TestReadBSORouteUnauthorized:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "headers": {},
                 "requestContext": {"authorizer": {}},
             }
@@ -615,7 +719,11 @@ class TestDeleteBSORouteUnauthorized:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "requestContext": {"authorizer": {}},
             }
         )
@@ -637,7 +745,11 @@ class TestUpdateBSORouteUnauthorized:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {}},
@@ -670,7 +782,11 @@ class TestReadBSORouteConditionalGET:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "headers": {"x-if-modified-since": "1234567890.12"},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -696,7 +812,11 @@ class TestReadBSORouteConditionalGET:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "headers": {"x-if-modified-since": "1234567890.12"},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -715,7 +835,11 @@ class TestReadBSORouteConditionalGET:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "headers": {"x-if-modified-since": "invalid"},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -734,7 +858,11 @@ class TestReadBSORouteConditionalGET:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "headers": {"x-if-modified-since": "-123.45"},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -753,7 +881,11 @@ class TestReadBSORouteConditionalGET:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "headers": {
                     "x-if-modified-since": "1234567890.12",
                     "x-if-unmodified-since": "1234567890.12",
@@ -780,7 +912,11 @@ class TestReadBSORouteInvalidInputs:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid name!", "objectId": "item123"},
+                    "pathParameters": {
+                        "uid": "12345",
+                        "collectionName": "invalid name!",
+                        "objectId": "item123",
+                    },
                     "headers": {},
                 }
             )
@@ -798,7 +934,11 @@ class TestReadBSORouteInvalidInputs:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks", "objectId": "invalid\x01id"},
+                    "pathParameters": {
+                        "uid": "12345",
+                        "collectionName": "bookmarks",
+                        "objectId": "invalid\x01id",
+                    },
                     "headers": {},
                 }
             )
@@ -821,6 +961,7 @@ class TestUpdateBSORouteInvalidCollectionName:
             with_auth(
                 {
                     "pathParameters": {
+                        "uid": "12345",
                         "collectionName": "invalid name!",
                         "objectId": "item123",
                     },
@@ -846,7 +987,11 @@ class TestDeleteBSORouteInvalidInputs:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid name!", "objectId": "item123"},
+                    "pathParameters": {
+                        "uid": "12345",
+                        "collectionName": "invalid name!",
+                        "objectId": "item123",
+                    },
                 }
             )
         )
@@ -863,7 +1008,11 @@ class TestDeleteBSORouteInvalidInputs:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks", "objectId": "invalid\x01id"},
+                    "pathParameters": {
+                        "uid": "12345",
+                        "collectionName": "bookmarks",
+                        "objectId": "invalid\x01id",
+                    },
                 }
             )
         )
@@ -886,7 +1035,11 @@ class TestUpdateBSORouteValidation:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "item123", "payload": large_payload}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -908,7 +1061,11 @@ class TestUpdateBSORouteValidation:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": long_id},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": long_id,
+                },
                 "body": json.dumps({"object": {"id": long_id, "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -930,7 +1087,11 @@ class TestUpdateBSORouteValidation:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": invalid_id},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": invalid_id,
+                },
                 "body": json.dumps({"object": {"id": invalid_id, "payload": "data"}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -950,7 +1111,11 @@ class TestUpdateBSORouteValidation:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps(
                     {"object": {"id": "item123", "payload": "data", "sortindex": "not_an_int"}}
                 ),
@@ -972,7 +1137,11 @@ class TestUpdateBSORouteValidation:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps(
                     {"object": {"id": "item123", "payload": "data", "sortindex": 1000000000}}
                 ),
@@ -994,7 +1163,11 @@ class TestUpdateBSORouteValidation:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps(
                     {"object": {"id": "item123", "payload": "data", "ttl": "not_an_int"}}
                 ),
@@ -1016,7 +1189,11 @@ class TestUpdateBSORouteValidation:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps({"object": {"id": "item123", "payload": "data", "ttl": -100}}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -1036,7 +1213,11 @@ class TestUpdateBSORouteValidation:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks", "objectId": "item123"},
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
                 "body": json.dumps(
                     {"object": {"id": "item123", "payload": "data", "ttl": 1000000000}}
                 ),

--- a/lambda/tests/routes/test_collection_routes.py
+++ b/lambda/tests/routes/test_collection_routes.py
@@ -44,8 +44,8 @@ class TestCreateCollectionRoute:
         event: dict[str, Any] = with_auth(
             {
                 "httpMethod": "POST",
-                "path": "/storage/bookmarks",
-                "pathParameters": {"collectionName": "bookmarks"},
+                "path": "/1.5/12345/storage/bookmarks",
+                "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                 "headers": {},
                 "body": None,
             }
@@ -60,7 +60,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": json.dumps(
                         {
@@ -107,7 +107,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "tabs"},
+                    "pathParameters": {"uid": "12345", "collectionName": "tabs"},
                     "headers": {},
                     "body": json.dumps(
                         [{"id": "tab1", "payload": "data1"}, {"id": "tab2", "payload": "data2"}]
@@ -143,7 +143,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "history"},
+                    "pathParameters": {"uid": "12345", "collectionName": "history"},
                     "headers": {},
                     "body": None,
                 }
@@ -175,7 +175,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"X-If-Unmodified-Since": "1234567889.00"},
                     "body": json.dumps({"objects": []}),
                 }
@@ -201,7 +201,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"X-If-Unmodified-Since": "1234567891.00"},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -243,7 +243,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": "invalid json{",
                 }
@@ -261,7 +261,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid!"},
+                    "pathParameters": {"uid": "12345", "collectionName": "invalid!"},
                     "headers": {},
                     "body": None,
                 }
@@ -283,7 +283,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": None,
                 }
@@ -303,7 +303,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": None,
                 }
@@ -323,7 +323,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"x-weave-records": "150"},  # Exceeds 100 limit
                     "body": json.dumps([]),
                 }
@@ -344,7 +344,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"x-weave-bytes": "3000000"},  # Exceeds 2MB limit
                     "body": json.dumps([]),
                 }
@@ -365,7 +365,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"x-weave-records": "invalid"},
                     "body": json.dumps([]),
                 }
@@ -383,7 +383,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"x-weave-bytes": "invalid"},
                     "body": json.dumps([]),
                 }
@@ -401,7 +401,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"x-weave-records": "5"},  # Says 5 records
                     "body": json.dumps([{"id": "obj1", "payload": "data"}]),  # But only 1
                 }
@@ -419,7 +419,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"x-weave-bytes": "1000"},  # Valid bytes
                     "body": json.dumps([{"id": "obj1", "payload": "data"}]),
                 }
@@ -453,7 +453,7 @@ class TestCreateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"x-weave-records": "1"},  # Matches actual count
                     "body": json.dumps([{"id": "obj1", "payload": "data"}]),
                 }
@@ -501,8 +501,8 @@ class TestReadCollectionRoute:
         event = with_auth(
             {
                 "httpMethod": "GET",
-                "path": "/storage/bookmarks",
-                "pathParameters": {"collectionName": "bookmarks"},
+                "path": "/1.5/12345/storage/bookmarks",
+                "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                 "queryStringParameters": None,
                 "headers": {},
                 "body": None,
@@ -518,7 +518,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {},
                 }
@@ -548,7 +548,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": {
                         "newer": "1234567880.00",
                         "limit": "10",
@@ -591,7 +591,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "history"},
+                    "pathParameters": {"uid": "12345", "collectionName": "history"},
                     "queryStringParameters": {"limit": "5", "offset": "10"},
                     "headers": {},
                 }
@@ -632,7 +632,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "tabs"},
+                    "pathParameters": {"uid": "12345", "collectionName": "tabs"},
                     "queryStringParameters": {"ids": "obj1,obj2", "full": "1"},
                     "headers": {},
                 }
@@ -669,7 +669,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid!"},
+                    "pathParameters": {"uid": "12345", "collectionName": "invalid!"},
                     "queryStringParameters": None,
                     "headers": {},
                 }
@@ -689,7 +689,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "nonexistent"},
+                    "pathParameters": {"uid": "12345", "collectionName": "nonexistent"},
                     "queryStringParameters": None,
                     "headers": {},
                 }
@@ -719,7 +719,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {},
                 }
@@ -739,7 +739,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {"x-if-modified-since": "1234567890.12"},
                 }
@@ -764,7 +764,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {"x-if-modified-since": "1234567880.00"},
                 }
@@ -789,7 +789,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {
                         "x-if-modified-since": "1234567890.12",
@@ -810,7 +810,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {"x-if-modified-since": "invalid"},
                 }
@@ -828,7 +828,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {"x-if-modified-since": "-1.0"},
                 }
@@ -846,7 +846,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {},
                 }
@@ -871,7 +871,7 @@ class TestReadCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                     "headers": {},
                 }
@@ -917,8 +917,8 @@ class TestUpdateCollectionRoute:
         event = with_auth(
             {
                 "httpMethod": "PUT",
-                "path": "/storage/bookmarks",
-                "pathParameters": {"collectionName": "bookmarks"},
+                "path": "/1.5/12345/storage/bookmarks",
+                "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                 "headers": {},
                 "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
             }
@@ -933,7 +933,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "updated"}]}),
                 }
@@ -967,7 +967,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": "invalid json{",
                 }
@@ -985,7 +985,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": json.dumps({"data": []}),
                 }
@@ -1003,7 +1003,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"X-If-Unmodified-Since": "1234567890"},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -1037,7 +1037,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"X-If-Unmodified-Since": "1234567890"},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -1074,7 +1074,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {"X-If-Unmodified-Since": "invalid"},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -1092,7 +1092,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid!"},
+                    "pathParameters": {"uid": "12345", "collectionName": "invalid!"},
                     "headers": {},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -1112,7 +1112,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "nonexistent"},
+                    "pathParameters": {"uid": "12345", "collectionName": "nonexistent"},
                     "headers": {},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -1134,7 +1134,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -1154,7 +1154,7 @@ class TestUpdateCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "headers": {},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -1181,8 +1181,8 @@ class TestDeleteCollectionRoute:
         event = with_auth(
             {
                 "httpMethod": "DELETE",
-                "path": "/storage/bookmarks",
-                "pathParameters": {"collectionName": "bookmarks"},
+                "path": "/1.5/12345/storage/bookmarks",
+                "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                 "queryStringParameters": None,
                 "headers": {},
                 "body": None,
@@ -1198,7 +1198,7 @@ class TestDeleteCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                 }
             )
@@ -1221,7 +1221,7 @@ class TestDeleteCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid!"},
+                    "pathParameters": {"uid": "12345", "collectionName": "invalid!"},
                     "queryStringParameters": None,
                 }
             )
@@ -1240,7 +1240,7 @@ class TestDeleteCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "nonexistent"},
+                    "pathParameters": {"uid": "12345", "collectionName": "nonexistent"},
                     "queryStringParameters": None,
                 }
             )
@@ -1261,7 +1261,7 @@ class TestDeleteCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": None,
                 }
             )
@@ -1280,7 +1280,7 @@ class TestDeleteCollectionRoute:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "bookmarks"},
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                     "queryStringParameters": {"ids": "obj1,obj2,obj3"},
                 }
             )
@@ -1312,8 +1312,8 @@ class TestListCollectionsRoute:
         event: dict[str, Any] = with_auth(
             {
                 "httpMethod": "GET",
-                "path": "/storage",
-                "pathParameters": None,
+                "path": "/1.5/12345/storage",
+                "pathParameters": {"uid": "12345"},
                 "queryStringParameters": None,
                 "headers": {},
                 "body": None,
@@ -1386,7 +1386,7 @@ class TestCreateCollectionRouteUnauthorized:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks"},
+                "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                 "body": json.dumps({"objects": []}),
                 "headers": {},
                 "requestContext": {"authorizer": {}},
@@ -1410,7 +1410,7 @@ class TestDeleteCollectionRouteUnauthorized:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks"},
+                "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                 "requestContext": {"authorizer": {}},
             }
         )
@@ -1453,7 +1453,7 @@ class TestReadCollectionRouteUnauthorized:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks"},
+                "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                 "requestContext": {"authorizer": {}},
             }
         )
@@ -1475,7 +1475,7 @@ class TestUpdateCollectionRouteUnauthorized:
 
         event = APIGatewayProxyEvent(
             {
-                "pathParameters": {"collectionName": "bookmarks"},
+                "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
                 "body": json.dumps({"objects": []}),
                 "headers": {},
                 "requestContext": {"authorizer": {}},
@@ -1500,7 +1500,7 @@ class TestCreateCollectionRouteInvalidCollectionName:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid name!"},
+                    "pathParameters": {"uid": "12345", "collectionName": "invalid name!"},
                     "headers": {},
                     "body": None,
                 }
@@ -1523,7 +1523,7 @@ class TestReadCollectionRouteInvalidCollectionName:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid name!"},
+                    "pathParameters": {"uid": "12345", "collectionName": "invalid name!"},
                     "queryStringParameters": None,
                     "headers": {},
                 }
@@ -1546,7 +1546,7 @@ class TestUpdateCollectionRouteInvalidCollectionName:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid name!"},
+                    "pathParameters": {"uid": "12345", "collectionName": "invalid name!"},
                     "headers": {},
                     "body": json.dumps({"objects": [{"id": "obj1", "payload": "data"}]}),
                 }
@@ -1569,7 +1569,7 @@ class TestDeleteCollectionRouteInvalidCollectionName:
         event = APIGatewayProxyEvent(
             with_auth(
                 {
-                    "pathParameters": {"collectionName": "invalid name!"},
+                    "pathParameters": {"uid": "12345", "collectionName": "invalid name!"},
                     "queryStringParameters": None,
                 }
             )

--- a/lambda/tests/routes/test_info_routes.py
+++ b/lambda/tests/routes/test_info_routes.py
@@ -38,8 +38,8 @@ class TestReadCollectionsInfoRoute:
         event: dict[str, Any] = with_auth(
             {
                 "httpMethod": "GET",
-                "path": "/info/collections",
-                "pathParameters": None,
+                "path": "/1.5/12345/info/collections",
+                "pathParameters": {"uid": "12345"},
                 "headers": {},
                 "body": None,
             }
@@ -134,8 +134,8 @@ class TestReadCollectionCountsRoute:
         event: dict[str, Any] = with_auth(
             {
                 "httpMethod": "GET",
-                "path": "/info/collection_counts",
-                "pathParameters": None,
+                "path": "/1.5/12345/info/collection_counts",
+                "pathParameters": {"uid": "12345"},
                 "headers": {},
                 "body": None,
             }
@@ -221,8 +221,8 @@ class TestReadCollectionUsageRoute:
         event: dict[str, Any] = with_auth(
             {
                 "httpMethod": "GET",
-                "path": "/info/collection_usage",
-                "pathParameters": None,
+                "path": "/1.5/12345/info/collection_usage",
+                "pathParameters": {"uid": "12345"},
                 "headers": {},
                 "body": None,
             }
@@ -308,8 +308,8 @@ class TestReadQuotaInfoRoute:
         event: dict[str, Any] = with_auth(
             {
                 "httpMethod": "GET",
-                "path": "/info/quota",
-                "pathParameters": None,
+                "path": "/1.5/12345/info/quota",
+                "pathParameters": {"uid": "12345"},
                 "headers": {},
                 "body": None,
             }
@@ -520,8 +520,8 @@ class TestReadConfigurationRoute:
 
         event: dict[str, Any] = {
             "httpMethod": "GET",
-            "path": "/info/configuration",
-            "pathParameters": None,
+            "path": "/1.5/12345/info/configuration",
+            "pathParameters": {"uid": "12345"},
             "headers": {},
             "body": None,
         }

--- a/lambda/tests/routes/test_storage_routes.py
+++ b/lambda/tests/routes/test_storage_routes.py
@@ -12,8 +12,8 @@ def build_storage_event(method: str, path: str, user_id: str = TEST_USER_ID) -> 
     """Build a storage API event with authentication context"""
     return {
         "httpMethod": method,
-        "path": path,
-        "pathParameters": None,
+        "path": f"/1.5/12345{path}",
+        "pathParameters": {"uid": "12345"},
         "headers": {},
         "body": None,
         "queryStringParameters": None,
@@ -221,8 +221,8 @@ class TestDeleteAllStorageRoute:
         """Test handling when user_id is missing from authorizer context"""
         event: dict[str, Any] = {
             "httpMethod": "DELETE",
-            "path": "/storage",
-            "pathParameters": None,
+            "path": "/1.5/12345/storage",
+            "pathParameters": {"uid": "12345"},
             "headers": {},
             "body": None,
             "queryStringParameters": None,

--- a/lambda/tests/services/test_api_router.py
+++ b/lambda/tests/services/test_api_router.py
@@ -197,7 +197,7 @@ def test_request_logging_middleware_logs_request_and_response():
         mock_app = MagicMock()
         mock_app.current_event = {
             "httpMethod": "GET",
-            "path": "/storage/bookmarks",
+            "path": "/1.5/12345/storage/bookmarks",
             "requestContext": {"authorizer": {"user_id": "user123"}},
         }
         mock_response = Response(status_code=200, body='{"test": "data"}')
@@ -210,14 +210,14 @@ def test_request_logging_middleware_logs_request_and_response():
         first_call = mock_logger.info.call_args_list[0]
         assert first_call[0][0] == "Request received"
         assert first_call[1]["extra"]["method"] == "GET"
-        assert first_call[1]["extra"]["path"] == "/storage/bookmarks"
+        assert first_call[1]["extra"]["path"] == "/1.5/12345/storage/bookmarks"
         assert first_call[1]["extra"]["user_id"] == "user123"
 
         # Verify request completed was logged
         second_call = mock_logger.info.call_args_list[1]
         assert second_call[0][0] == "Request completed"
         assert second_call[1]["extra"]["method"] == "GET"
-        assert second_call[1]["extra"]["path"] == "/storage/bookmarks"
+        assert second_call[1]["extra"]["path"] == "/1.5/12345/storage/bookmarks"
         assert second_call[1]["extra"]["user_id"] == "user123"
         assert second_call[1]["extra"]["status_code"] == 200
         assert "duration_ms" in second_call[1]["extra"]
@@ -233,7 +233,7 @@ def test_request_logging_middleware_logs_anonymous_user():
         mock_app = MagicMock()
         mock_app.current_event = {
             "httpMethod": "GET",
-            "path": "/info/configuration",
+            "path": "/1.5/12345/info/configuration",
             "requestContext": {},
         }
         mock_response = Response(status_code=200, body='{"test": "data"}')
@@ -253,7 +253,7 @@ def test_request_logging_middleware_logs_errors():
         mock_app = MagicMock()
         mock_app.current_event = {
             "httpMethod": "POST",
-            "path": "/storage/bookmarks",
+            "path": "/1.5/12345/storage/bookmarks",
             "requestContext": {"authorizer": {"user_id": "user123"}},
         }
         test_exception = ValueError("Test error")
@@ -274,7 +274,7 @@ def test_request_logging_middleware_logs_errors():
         error_call = mock_logger.error.call_args
         assert error_call[0][0] == "Request failed"
         assert error_call[1]["extra"]["method"] == "POST"
-        assert error_call[1]["extra"]["path"] == "/storage/bookmarks"
+        assert error_call[1]["extra"]["path"] == "/1.5/12345/storage/bookmarks"
         assert error_call[1]["extra"]["user_id"] == "user123"
         assert error_call[1]["extra"]["error_type"] == "ValueError"
         assert error_call[1]["extra"]["error_message"] == "Test error"
@@ -290,7 +290,7 @@ def test_request_logging_middleware_never_logs_payloads():
         # Event with body containing sensitive data
         mock_app.current_event = {
             "httpMethod": "PUT",
-            "path": "/storage/bookmarks/abc123",
+            "path": "/1.5/12345/storage/bookmarks/abc123",
             "body": '{"payload": "sensitive encrypted data", "sortindex": 100}',
             "requestContext": {"authorizer": {"user_id": "user123"}},
         }

--- a/smithy/models/storage/bso.smithy
+++ b/smithy/models/storage/bso.smithy
@@ -50,7 +50,7 @@ structure BasicStorageObjectInput {
 }
 
 @readonly
-@http(method: "GET", uri: "/storage/{collectionName}/{objectId}")
+@http(method: "GET", uri: "/1.5/{uid}/storage/{collectionName}/{objectId}")
 @documentation("Get a specific storage object")
 operation GetBasicStorageObject {
     input: GetBasicStorageObjectInput
@@ -63,7 +63,7 @@ operation GetBasicStorageObject {
 }
 
 @idempotent
-@http(method: "PUT", uri: "/storage/{collectionName}/{objectId}")
+@http(method: "PUT", uri: "/1.5/{uid}/storage/{collectionName}/{objectId}")
 @documentation("Update a storage object")
 operation UpdateBasicStorageObject {
     input: UpdateBasicStorageObjectInput
@@ -79,7 +79,7 @@ operation UpdateBasicStorageObject {
 }
 
 @idempotent
-@http(method: "DELETE", uri: "/storage/{collectionName}/{objectId}")
+@http(method: "DELETE", uri: "/1.5/{uid}/storage/{collectionName}/{objectId}")
 @documentation("Delete a specific storage object")
 operation DeleteBasicStorageObject {
     input: DeleteBasicStorageObjectInput
@@ -92,6 +92,10 @@ operation DeleteBasicStorageObject {
 }
 
 structure GetBasicStorageObjectInput {
+    @httpLabel
+    @required
+    uid: String
+
     @httpLabel
     @required
     collectionName: CollectionName
@@ -110,6 +114,10 @@ structure GetBasicStorageObjectOutput {
 }
 
 structure UpdateBasicStorageObjectInput {
+    @httpLabel
+    @required
+    uid: String
+
     @httpLabel
     @required
     collectionName: CollectionName
@@ -135,6 +143,10 @@ structure UpdateBasicStorageObjectOutput {
 }
 
 structure DeleteBasicStorageObjectInput {
+    @httpLabel
+    @required
+    uid: String
+
     @httpLabel
     @required
     collectionName: CollectionName

--- a/smithy/models/storage/collection.smithy
+++ b/smithy/models/storage/collection.smithy
@@ -20,7 +20,7 @@ resource Collection {
 }
 
 @readonly
-@http(method: "GET", uri: "/storage")
+@http(method: "GET", uri: "/1.5/{uid}/storage")
 @documentation("List all collections with their metadata")
 operation ListCollections {
     input: ListCollectionsInput
@@ -31,7 +31,11 @@ operation ListCollections {
 }
 
 // Collection CRUD Operations
-structure ListCollectionsInput {}
+structure ListCollectionsInput {
+    @httpLabel
+    @required
+    uid: String
+}
 
 structure ListCollectionsOutput {
     @documentation("List of collections with their metadata")
@@ -51,6 +55,10 @@ structure BatchObjectsPayload {
 
 @input
 structure CreateCollectionInput {
+    @httpLabel
+    @required
+    uid: String
+
     @httpLabel
     @required
     collectionName: CollectionName
@@ -76,7 +84,7 @@ structure CreateCollectionOutput {
 }
 
 @idempotent
-@http(method: "POST", uri: "/storage/{collectionName}")
+@http(method: "POST", uri: "/1.5/{uid}/storage/{collectionName}")
 @documentation("Create a new collection or batch create/update objects")
 operation CreateCollection {
     input: CreateCollectionInput
@@ -92,6 +100,10 @@ operation CreateCollection {
 
 @input
 structure GetCollectionInput {
+    @httpLabel
+    @required
+    uid: String
+
     @httpLabel
     @required
     collectionName: CollectionName
@@ -144,7 +156,7 @@ structure GetCollectionOutput {
 }
 
 @readonly
-@http(method: "GET", uri: "/storage/{collectionName}")
+@http(method: "GET", uri: "/1.5/{uid}/storage/{collectionName}")
 @documentation("Get collection metadata or retrieve objects with filtering")
 operation GetCollection {
     input: GetCollectionInput
@@ -158,6 +170,10 @@ operation GetCollection {
 
 @input
 structure UpdateCollectionInput {
+    @httpLabel
+    @required
+    uid: String
+
     @httpLabel
     @required
     collectionName: CollectionName
@@ -180,7 +196,7 @@ structure UpdateCollectionOutput {
 }
 
 @idempotent
-@http(method: "PUT", uri: "/storage/{collectionName}")
+@http(method: "PUT", uri: "/1.5/{uid}/storage/{collectionName}")
 @documentation("Update collection with batch objects")
 operation UpdateCollection {
     input: UpdateCollectionInput
@@ -196,7 +212,7 @@ operation UpdateCollection {
 }
 
 @idempotent
-@http(method: "DELETE", uri: "/storage/{collectionName}")
+@http(method: "DELETE", uri: "/1.5/{uid}/storage/{collectionName}")
 @documentation("Delete an entire collection")
 operation DeleteCollection {
     input: DeleteCollectionInput
@@ -210,6 +226,10 @@ operation DeleteCollection {
 
 @input
 structure DeleteCollectionInput {
+    @httpLabel
+    @required
+    uid: String
+
     @httpLabel
     @required
     collectionName: CollectionName

--- a/smithy/models/storage/storage.smithy
+++ b/smithy/models/storage/storage.smithy
@@ -43,7 +43,7 @@ resource QuotaInfo { read: GetQuotaInfo }
 resource ConfigurationInfo { read: GetConfigurationInfo }
 
 @idempotent
-@http(method: "DELETE", uri: "/storage")
+@http(method: "DELETE", uri: "/1.5/{uid}/storage")
 @documentation("Delete all storage data for the authenticated user")
 operation DeleteAllStorage {
     input: DeleteAllStorageInput
@@ -54,7 +54,7 @@ operation DeleteAllStorage {
 }
 
 @idempotent
-@http(method: "DELETE", uri: "/")
+@http(method: "DELETE", uri: "/1.5/{uid}")
 @documentation("Delete all storage data for the authenticated user (root endpoint)")
 operation DeleteAllRootStorage {
     input: DeleteAllRootStorageInput
@@ -65,7 +65,7 @@ operation DeleteAllRootStorage {
 }
 
 @readonly
-@http(method: "GET", uri: "/info/collections")
+@http(method: "GET", uri: "/1.5/{uid}/info/collections")
 @documentation("Get metadata for all collections")
 operation GetStorageInfo {
     input: GetStorageInfoInput
@@ -76,7 +76,7 @@ operation GetStorageInfo {
 }
 
 @readonly
-@http(method: "GET", uri: "/info/collection_counts")
+@http(method: "GET", uri: "/1.5/{uid}/info/collection_counts")
 @documentation("Get object counts for all collections")
 operation GetCollectionCounts {
     input: GetCollectionCountsInput
@@ -87,7 +87,7 @@ operation GetCollectionCounts {
 }
 
 @readonly
-@http(method: "GET", uri: "/info/collection_usage")
+@http(method: "GET", uri: "/1.5/{uid}/info/collection_usage")
 @documentation("Get storage usage for all collections")
 operation GetCollectionUsage {
     input: GetCollectionUsageInput
@@ -98,7 +98,7 @@ operation GetCollectionUsage {
 }
 
 @readonly
-@http(method: "GET", uri: "/info/quota")
+@http(method: "GET", uri: "/1.5/{uid}/info/quota")
 @documentation("Get storage quota information")
 operation GetQuotaInfo {
     input: GetQuotaInfoInput
@@ -109,7 +109,7 @@ operation GetQuotaInfo {
 }
 
 @readonly
-@http(method: "GET", uri: "/info/configuration")
+@http(method: "GET", uri: "/1.5/{uid}/info/configuration")
 @documentation("Get server configuration limits")
 operation GetConfigurationInfo {
     input: GetConfigurationInfoInput
@@ -165,7 +165,11 @@ list StringList {
 }
 
 @input
-structure DeleteAllStorageInput {}
+structure DeleteAllStorageInput {
+    @httpLabel
+    @required
+    uid: String
+}
 
 @output
 structure DeleteAllStorageOutput {
@@ -174,7 +178,11 @@ structure DeleteAllStorageOutput {
 }
 
 @input
-structure DeleteAllRootStorageInput {}
+structure DeleteAllRootStorageInput {
+    @httpLabel
+    @required
+    uid: String
+}
 
 @output
 structure DeleteAllRootStorageOutput {
@@ -183,7 +191,11 @@ structure DeleteAllRootStorageOutput {
 }
 
 // Info Operations
-structure GetStorageInfoInput {}
+structure GetStorageInfoInput {
+    @httpLabel
+    @required
+    uid: String
+}
 
 structure GetStorageInfoOutput {
     @documentation("Map of collection names to their last modified timestamps")
@@ -196,21 +208,33 @@ map CollectionTimestamps {
     value: Timestamp
 }
 
-structure GetCollectionCountsInput {}
+structure GetCollectionCountsInput {
+    @httpLabel
+    @required
+    uid: String
+}
 
 structure GetCollectionCountsOutput {
     @documentation("Map of collection names to object counts")
     counts: CollectionCounts
 }
 
-structure GetCollectionUsageInput {}
+structure GetCollectionUsageInput {
+    @httpLabel
+    @required
+    uid: String
+}
 
 structure GetCollectionUsageOutput {
     @documentation("Map of collection names to usage in KB")
     usage: CollectionUsage
 }
 
-structure GetQuotaInfoInput {}
+structure GetQuotaInfoInput {
+    @httpLabel
+    @required
+    uid: String
+}
 
 structure GetQuotaInfoOutput {
     @documentation("Two-item list: [usage_kb, quota_kb or null]")
@@ -223,7 +247,11 @@ list QuotaArray {
     member: Long
 }
 
-structure GetConfigurationInfoInput {}
+structure GetConfigurationInfoInput {
+    @httpLabel
+    @required
+    uid: String
+}
 
 structure GetConfigurationInfoOutput {
     @documentation("Maximum number of records per POST request")


### PR DESCRIPTION
## Summary

- Firefox Sync clients receive `api_endpoint` with `/1.5/{uid}` prefix from the token server and append collection paths (e.g. `info/collections`, `storage/bookmarks`). The storage API routes were defined without this prefix, so API Gateway returned 403 for all storage requests before the Hawk authorizer was even invoked.
- Adds `/1.5/{uid}` prefix to all 15 storage operations across Smithy models, Lambda route handlers, and tests. The `uid` path parameter is accepted but unused — handlers continue to get user identity from the Hawk authorizer context.

## Test plan

- [ ] `cd lambda && .venv/bin/python -m pytest tests/ -x -q` — 915 passed, 100% coverage
- [ ] `cd smithy && gradle smithyBuild --rerun-tasks` — regenerate OpenAPI spec with new paths
- [ ] Deploy and verify `GET /1.5/{uid}/info/collections` returns 200 instead of 403