### PR TITLE
fix: align storage API with SyncStorage v1.5 spec

### DIFF
--- a/lambda/src/routes/bso/read.py
+++ b/lambda/src/routes/bso/read.py
@@ -104,12 +104,10 @@ class ReadBSORoute(BaseRoute):
             if obj_dict.get("sortindex") is None:
                 del obj_dict["sortindex"]
 
-            response_body = {"object": obj_dict}
-
             return Response(
                 status_code=200,
                 content_type="application/json",
-                body=json_dumps(response_body),
+                body=json_dumps(obj_dict),
                 headers={"X-Last-Modified": str(obj_dict["modified"])},
             )
 

--- a/lambda/src/routes/bso/update.py
+++ b/lambda/src/routes/bso/update.py
@@ -1,6 +1,4 @@
 import json
-from datetime import datetime, timezone
-from typing import Any
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
@@ -15,7 +13,6 @@ from src.shared.exceptions import (
     ValidationException,
 )
 from src.shared.models import (
-    BasicStorageObject,
     ValidationError,
     validate_bso_id,
     validate_collection_name,
@@ -58,55 +55,46 @@ class UpdateBSORoute(BaseRoute):
             except ValidationError as e:
                 raise ValidationException(str(e))
 
-            # Parse object from request body
+            # Parse BSO fields directly from request body (per SyncStorage API v1.5 spec)
             try:
-                body_data = json.loads(body)
-                obj_data = body_data["object"]
+                obj_data = json.loads(body)
+            except (json.JSONDecodeError, TypeError) as e:
+                raise ValidationException(f"Invalid request body: {e}")
 
-                # Validate BSO ID (Requirements 10.2, 10.3)
-                bso_id = obj_data["id"]
-                try:
-                    validate_bso_id(bso_id)
-                except ValidationError as e:
-                    raise ValidationException(str(e))
+            if not isinstance(obj_data, dict):
+                raise ValidationException("Invalid request body: expected JSON object")
 
-                # Validate that object ID in body matches path parameter
-                if bso_id != object_id:
-                    raise ValidationException("Object ID in body must match path parameter")
+            # Validate BSO ID from path parameter (Requirements 10.2, 10.3)
+            try:
+                validate_bso_id(object_id)
+            except ValidationError as e:
+                raise ValidationException(str(e))
 
-                # Validate payload size (Requirement 10.1)
-                payload = obj_data["payload"]
+            # If body contains id, validate it matches the path parameter
+            if "id" in obj_data and obj_data["id"] != object_id:
+                raise ValidationException("Object ID in body must match path parameter")
+
+            # Validate payload size if provided (Requirement 10.1)
+            payload = obj_data.get("payload")
+            if payload is not None:
                 try:
                     validate_payload_size(payload)
                 except ValidationError as e:
                     raise RequestTooLargeException(str(e))
 
-                # Validate sortindex if provided
-                sortindex = obj_data.get("sortindex")
-                try:
-                    validate_sortindex(sortindex)
-                except ValidationError as e:
-                    raise ValidationException(str(e))
+            # Validate sortindex if provided
+            sortindex = obj_data.get("sortindex")
+            try:
+                validate_sortindex(sortindex)
+            except ValidationError as e:
+                raise ValidationException(str(e))
 
-                # Validate TTL if provided
-                ttl = obj_data.get("ttl")
-                try:
-                    validate_ttl(ttl)
-                except ValidationError as e:
-                    raise ValidationException(str(e))
-
-                storage_object = BasicStorageObject(
-                    id=bso_id,
-                    payload=payload,
-                    sortindex=sortindex,
-                    ttl=ttl,
-                    modified=datetime.fromtimestamp(
-                        0, tz=timezone.utc
-                    ),  # Will be set by DynamoDB service
-                )
-
-            except (json.JSONDecodeError, KeyError) as e:
-                raise ValidationException(f"Invalid request body: {e}")
+            # Validate TTL if provided
+            ttl = obj_data.get("ttl")
+            try:
+                validate_ttl(ttl)
+            except ValidationError as e:
+                raise ValidationException(str(e))
 
             # Handle conditional update header (Requirements 5.1-5.3)
             if_unmodified_since = None
@@ -123,29 +111,19 @@ class UpdateBSORoute(BaseRoute):
                 collection_name,
                 object_id,
                 if_unmodified_since=if_unmodified_since,
-                payload=storage_object.payload,
-                sortindex=storage_object.sortindex,
-                ttl=storage_object.ttl,
+                payload=payload,
+                sortindex=sortindex,
+                ttl=ttl,
             )
 
-            # Convert to dict using dataclass serialization
-            obj_dict = updated_object.to_dict()
-
-            # Remove None values
-            if obj_dict.get("sortindex") is None:
-                del obj_dict["sortindex"]
-            if obj_dict.get("ttl") is None:
-                del obj_dict["ttl"]
-
-            response_body: dict[str, Any] = {
-                "object": obj_dict,
-                "modified": obj_dict["modified"],
-            }
+            # Per SyncStorage API v1.5 spec, PUT returns the new
+            # last-modified time for the collection as a plain number
+            modified = updated_object.modified.timestamp()
 
             return Response(
                 status_code=200,
                 content_type="application/json",
-                body=json_dumps(response_body),
+                body=json_dumps(modified),
             )
 
         except ValidationException as e:

--- a/lambda/src/routes/collections/update.py
+++ b/lambda/src/routes/collections/update.py
@@ -46,9 +46,20 @@ class UpdateCollectionRoute(BaseRoute):
             except ValidationError as e:
                 raise ValidationException(str(e))
 
-            # Parse objects from request body
+            # Parse objects from request body (per SyncStorage API v1.5 spec,
+            # body is a direct JSON array of BSOs)
             try:
                 body_data = json.loads(body)
+
+                # Handle direct array of objects (Mozilla API format)
+                if isinstance(body_data, list):
+                    objects_data = body_data
+                # Handle wrapped objects for backwards compatibility
+                elif isinstance(body_data, dict) and "objects" in body_data:
+                    objects_data = body_data["objects"]
+                else:
+                    raise ValidationException("Invalid request body: expected JSON array of BSOs")
+
                 objects = [
                     BasicStorageObject(
                         id=obj["id"],
@@ -59,7 +70,7 @@ class UpdateCollectionRoute(BaseRoute):
                             0, tz=timezone.utc
                         ),  # Will be set by DynamoDB service
                     )
-                    for obj in body_data["objects"]
+                    for obj in objects_data
                 ]
             except (json.JSONDecodeError, KeyError) as e:
                 raise ValidationException(f"Invalid request body: {e}")
@@ -81,13 +92,12 @@ class UpdateCollectionRoute(BaseRoute):
                 if_unmodified_since=if_unmodified_since,
             )
 
-            # Convert to dict using dataclass serialization
-            collection_dict = collection_data.to_dict()
-            batch_dict = batch_result.to_dict()
-
+            # Return Mozilla-compliant response format
+            # {"modified": timestamp, "success": [...], "failed": {...}}
             response_body = {
-                "collection": collection_dict,
-                "batchResult": batch_dict,
+                "modified": collection_data.modified.timestamp(),
+                "success": batch_result.success,
+                "failed": batch_result.failed,
             }
 
             return Response(

--- a/lambda/tests/routes/test_bso_routes.py
+++ b/lambda/tests/routes/test_bso_routes.py
@@ -1221,3 +1221,42 @@ class TestUpdateBSORouteValidation:
         assert response.body is not None
         body = json.loads(response.body)
         assert "TTL" in body["error"] and "exceeds" in body["error"]
+
+    def test_handle_no_payload(self, mock_storage_manager):
+        """Test successful update without payload (partial update)"""
+        route = UpdateBSORoute(mock_storage_manager)
+
+        event = APIGatewayProxyEvent(
+            {
+                "pathParameters": {
+                    "uid": "12345",
+                    "collectionName": "bookmarks",
+                    "objectId": "item123",
+                },
+                "body": json.dumps({"sortindex": 50}),
+                "headers": {},
+                "requestContext": {"authorizer": {"user_id": "test-user-123"}},
+            }
+        )
+
+        updated_bso = BasicStorageObject(
+            id="item123",
+            payload="existing_data",
+            modified=datetime.fromtimestamp(1234567891.00, tz=timezone.utc),
+            sortindex=50,
+            ttl=None,
+        )
+        mock_storage_manager.update_storage_object.return_value = updated_bso
+
+        response = route.handle(event)
+
+        assert response.status_code == 200
+        mock_storage_manager.update_storage_object.assert_called_once_with(
+            "test-user-123",
+            "bookmarks",
+            "item123",
+            if_unmodified_since=None,
+            payload=None,
+            sortindex=50,
+            ttl=None,
+        )

--- a/lambda/tests/routes/test_bso_routes.py
+++ b/lambda/tests/routes/test_bso_routes.py
@@ -1113,9 +1113,7 @@ class TestUpdateBSORouteValidation:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps(
-                    {"id": "item123", "payload": "data", "sortindex": "not_an_int"}
-                ),
+                "body": json.dumps({"id": "item123", "payload": "data", "sortindex": "not_an_int"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -1139,9 +1137,7 @@ class TestUpdateBSORouteValidation:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps(
-                    {"id": "item123", "payload": "data", "sortindex": 1000000000}
-                ),
+                "body": json.dumps({"id": "item123", "payload": "data", "sortindex": 1000000000}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -1165,9 +1161,7 @@ class TestUpdateBSORouteValidation:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps(
-                    {"id": "item123", "payload": "data", "ttl": "not_an_int"}
-                ),
+                "body": json.dumps({"id": "item123", "payload": "data", "ttl": "not_an_int"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -1215,9 +1209,7 @@ class TestUpdateBSORouteValidation:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps(
-                    {"id": "item123", "payload": "data", "ttl": 1000000000}
-                ),
+                "body": json.dumps({"id": "item123", "payload": "data", "ttl": 1000000000}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }

--- a/lambda/tests/routes/test_bso_routes.py
+++ b/lambda/tests/routes/test_bso_routes.py
@@ -87,12 +87,12 @@ class TestReadBSORoute:
 
         assert response.body is not None
         body = json.loads(response.body)
-        assert body["object"]["id"] == "item123"
-        assert body["object"]["payload"] == "bookmark_data"
-        assert body["object"]["modified"] == 1234567890.12
-        assert body["object"]["sortindex"] == 100
+        assert body["id"] == "item123"
+        assert body["payload"] == "bookmark_data"
+        assert body["modified"] == 1234567890.12
+        assert body["sortindex"] == 100
         # TTL is write-only per Mozilla spec (Requirement 11.4) - should not be in response
-        assert "ttl" not in body["object"]
+        assert "ttl" not in body
         assert response.headers["X-Last-Modified"] == "1234567890.12"
 
     def test_handle_success_without_optional_fields(self, mock_storage_manager):
@@ -124,8 +124,8 @@ class TestReadBSORoute:
         assert response.status_code == 200
         assert response.body is not None
         body = json.loads(response.body)
-        assert "sortindex" not in body["object"]
-        assert "ttl" not in body["object"]
+        assert "sortindex" not in body
+        assert "ttl" not in body
 
     def test_handle_validation_exception(self, mock_storage_manager):
         """Test handling of ValidationException"""
@@ -257,7 +257,7 @@ class TestUpdateBSORoute:
                 "objectId": "item123",
             },
             "headers": {},
-            "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
+            "body": json.dumps({"id": "item123", "payload": "data"}),
             "requestContext": {"authorizer": {"user_id": "test-user-123"}},
         }
         result = app.resolve(event, MagicMock())
@@ -276,12 +276,10 @@ class TestUpdateBSORoute:
                 },
                 "body": json.dumps(
                     {
-                        "object": {
-                            "id": "item123",
-                            "payload": "updated_data",
-                            "sortindex": 200,
-                            "ttl": 7200,
-                        }
+                        "id": "item123",
+                        "payload": "updated_data",
+                        "sortindex": 200,
+                        "ttl": 7200,
                     }
                 ),
                 "headers": {},
@@ -303,8 +301,7 @@ class TestUpdateBSORoute:
         assert response.status_code == 200
         assert response.body is not None
         body = json.loads(response.body)
-        assert body["object"]["id"] == "item123"
-        assert body["object"]["payload"] == "updated_data"
+        assert body == 1234567891.0
 
     def test_handle_invalid_json(self, mock_storage_manager):
         """Test handling of invalid JSON body"""
@@ -327,8 +324,8 @@ class TestUpdateBSORoute:
 
         assert response.status_code == 400
 
-    def test_handle_missing_object_key(self, mock_storage_manager):
-        """Test handling of missing 'object' key in body"""
+    def test_handle_non_object_body(self, mock_storage_manager):
+        """Test handling of non-object JSON body (e.g. array or string)"""
         route = UpdateBSORoute(mock_storage_manager)
 
         event = APIGatewayProxyEvent(
@@ -338,7 +335,7 @@ class TestUpdateBSORoute:
                     "collectionName": "bookmarks",
                     "objectId": "item",
                 },
-                "body": json.dumps({"payload": "data"}),
+                "body": json.dumps([1, 2, 3]),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -359,7 +356,7 @@ class TestUpdateBSORoute:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "different_id", "payload": "data"}}),
+                "body": json.dumps({"id": "different_id", "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -380,7 +377,7 @@ class TestUpdateBSORoute:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
+                "body": json.dumps({"id": "item123", "payload": "data"}),
                 "headers": {"X-If-Unmodified-Since": "1234567890"},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -410,7 +407,7 @@ class TestUpdateBSORoute:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
+                "body": json.dumps({"id": "item123", "payload": "data"}),
                 "headers": {"X-If-Unmodified-Since": "invalid"},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -431,7 +428,7 @@ class TestUpdateBSORoute:
                     "collectionName": "nonexistent",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
+                "body": json.dumps({"id": "item123", "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -456,7 +453,7 @@ class TestUpdateBSORoute:
                     "collectionName": "bookmarks",
                     "objectId": "nonexistent",
                 },
-                "body": json.dumps({"object": {"id": "nonexistent", "payload": "data"}}),
+                "body": json.dumps({"id": "nonexistent", "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -481,7 +478,7 @@ class TestUpdateBSORoute:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
+                "body": json.dumps({"id": "item123", "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -506,7 +503,7 @@ class TestUpdateBSORoute:
                     "collectionName": "invalid!",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
+                "body": json.dumps({"id": "item123", "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -529,7 +526,7 @@ class TestUpdateBSORoute:
                     "collectionName": "bookmarks",
                     "objectId": "item",
                 },
-                "body": json.dumps({"object": {"id": "item", "payload": "data"}}),
+                "body": json.dumps({"id": "item", "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -750,7 +747,7 @@ class TestUpdateBSORouteUnauthorized:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
+                "body": json.dumps({"id": "item123", "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {}},
             }
@@ -827,7 +824,7 @@ class TestReadBSORouteConditionalGET:
         assert response.status_code == 200
         assert response.body is not None
         body = json.loads(response.body)
-        assert body["object"]["id"] == "item123"
+        assert body["id"] == "item123"
 
     def test_handle_if_modified_since_invalid_format(self, mock_storage_manager):
         """Test 400 Bad Request for invalid X-If-Modified-Since header"""
@@ -965,7 +962,7 @@ class TestUpdateBSORouteInvalidCollectionName:
                         "collectionName": "invalid name!",
                         "objectId": "item123",
                     },
-                    "body": json.dumps({"object": {"id": "item123", "payload": "data"}}),
+                    "body": json.dumps({"id": "item123", "payload": "data"}),
                     "headers": {},
                 }
             )
@@ -1040,7 +1037,7 @@ class TestUpdateBSORouteValidation:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "item123", "payload": large_payload}}),
+                "body": json.dumps({"id": "item123", "payload": large_payload}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -1066,7 +1063,7 @@ class TestUpdateBSORouteValidation:
                     "collectionName": "bookmarks",
                     "objectId": long_id,
                 },
-                "body": json.dumps({"object": {"id": long_id, "payload": "data"}}),
+                "body": json.dumps({"id": long_id, "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -1092,7 +1089,7 @@ class TestUpdateBSORouteValidation:
                     "collectionName": "bookmarks",
                     "objectId": invalid_id,
                 },
-                "body": json.dumps({"object": {"id": invalid_id, "payload": "data"}}),
+                "body": json.dumps({"id": invalid_id, "payload": "data"}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -1117,7 +1114,7 @@ class TestUpdateBSORouteValidation:
                     "objectId": "item123",
                 },
                 "body": json.dumps(
-                    {"object": {"id": "item123", "payload": "data", "sortindex": "not_an_int"}}
+                    {"id": "item123", "payload": "data", "sortindex": "not_an_int"}
                 ),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -1143,7 +1140,7 @@ class TestUpdateBSORouteValidation:
                     "objectId": "item123",
                 },
                 "body": json.dumps(
-                    {"object": {"id": "item123", "payload": "data", "sortindex": 1000000000}}
+                    {"id": "item123", "payload": "data", "sortindex": 1000000000}
                 ),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -1169,7 +1166,7 @@ class TestUpdateBSORouteValidation:
                     "objectId": "item123",
                 },
                 "body": json.dumps(
-                    {"object": {"id": "item123", "payload": "data", "ttl": "not_an_int"}}
+                    {"id": "item123", "payload": "data", "ttl": "not_an_int"}
                 ),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
@@ -1194,7 +1191,7 @@ class TestUpdateBSORouteValidation:
                     "collectionName": "bookmarks",
                     "objectId": "item123",
                 },
-                "body": json.dumps({"object": {"id": "item123", "payload": "data", "ttl": -100}}),
+                "body": json.dumps({"id": "item123", "payload": "data", "ttl": -100}),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},
             }
@@ -1219,7 +1216,7 @@ class TestUpdateBSORouteValidation:
                     "objectId": "item123",
                 },
                 "body": json.dumps(
-                    {"object": {"id": "item123", "payload": "data", "ttl": 1000000000}}
+                    {"id": "item123", "payload": "data", "ttl": 1000000000}
                 ),
                 "headers": {},
                 "requestContext": {"authorizer": {"user_id": "test-user-123"}},

--- a/lambda/tests/routes/test_collection_routes.py
+++ b/lambda/tests/routes/test_collection_routes.py
@@ -978,6 +978,40 @@ class TestUpdateCollectionRoute:
 
         assert response.status_code == 400
 
+    def test_handle_direct_array_body(self, mock_storage_manager):
+        """Test batch update with direct JSON array body (SyncStorage API v1.5 format)"""
+        route = UpdateCollectionRoute(mock_storage_manager)
+
+        event = APIGatewayProxyEvent(
+            with_auth(
+                {
+                    "pathParameters": {"uid": "12345", "collectionName": "bookmarks"},
+                    "headers": {},
+                    "body": json.dumps([{"id": "obj1", "payload": "data"}]),
+                }
+            )
+        )
+
+        collection_data = CollectionData(
+            name="bookmarks",
+            modified=datetime.fromtimestamp(1234567891.00, tz=timezone.utc),
+            count=1,
+            usage=512,
+        )
+        batch_result = BatchResult(
+            success=["obj1"],
+            failed={},
+            modified=datetime.fromtimestamp(1234567891.00, tz=timezone.utc),
+        )
+        mock_storage_manager.update_collection.return_value = (
+            collection_data,
+            batch_result,
+        )
+
+        response = route.handle(event)
+
+        assert response.status_code == 200
+
     def test_handle_missing_objects_key(self, mock_storage_manager):
         """Test handling of missing 'objects' key in body"""
         route = UpdateCollectionRoute(mock_storage_manager)


### PR DESCRIPTION
## Summary

- **BSO PUT** (`/storage/{collection}/{id}`): Parse BSO fields directly from the top-level JSON body instead of expecting an `{"object": {...}}` wrapper. Make `payload` optional for partial updates. Return the modified timestamp as a plain number per spec.
- **BSO GET** (`/storage/{collection}/{id}`): Return the BSO as a flat JSON object instead of wrapping in `{"object": ...}`.
- **Collection PUT** (`/storage/{collection}`): Accept a direct JSON array of BSOs (spec format) with backwards-compatible fallback for `{"objects": [...]}`. Return `{"modified", "success", "failed"}` response format matching the POST endpoint.

## Context

Firefox Sync clients send BSO fields as flat JSON:
```json
{"payload": "{\"syncID\":\"...\",\"storageVersion\":5}", "id": "global", "modified": 0}
```

The server expected them nested under an `"object"` key, causing `400 Invalid request body: 'object'` on every `PUT /storage/meta/global`, which blocked initial sync setup entirely.

## Test plan

- [x] All 922 existing tests pass
- [x] Updated test request bodies to use flat BSO format
- [x] Updated test response assertions to match spec-compliant formats
- [ ] Verify Firefox/Waterfox sync completes initial setup against deployed server