### PR TITLE
fix: create/update collection metadata on single BSO PUT

### DIFF
--- a/lambda/src/services/storage_manager.py
+++ b/lambda/src/services/storage_manager.py
@@ -616,6 +616,7 @@ class StorageManager:
         from src.shared.exceptions import PreconditionFailedException
 
         # Get existing object to verify it exists
+        is_new_bso = False
         try:
             existing_obj = self.get_storage_object(user_id, collection_name, object_id)
 
@@ -636,6 +637,7 @@ class StorageManager:
                     )
         except StorageObjectNotFoundException:
             # Object doesn't exist
+            is_new_bso = True
             if if_unmodified_since is not None and if_unmodified_since != 0:
                 # Can't check precondition on non-existent object
                 raise PreconditionFailedException(
@@ -670,6 +672,36 @@ class StorageManager:
                 user_id=user_id, collection_name=collection_name, obj=obj
             )
         )
+
+        # Upsert collection metadata so list_collections reflects this write.
+        # DynamoDB update_item creates the item if it doesn't exist, and ADD
+        # initialises missing numeric attributes to 0 before adding.
+        usage_delta = len(payload) - len(existing_obj.payload)
+        count_delta = 1 if is_new_bso else 0
+
+        self.table.update_item(
+            Key={
+                "PK": self._collection_pk(user_id, collection_name),
+                "SK": self._metadata_sk(),
+            },
+            UpdateExpression="SET #modified = :modified, #name = :name, #user_id = :user_id"
+            " ADD #count :count_delta, #usage :usage_delta",
+            ExpressionAttributeNames={
+                "#modified": "modified",
+                "#name": "name",
+                "#user_id": "user_id",
+                "#count": "count",
+                "#usage": "usage",
+            },
+            ExpressionAttributeValues={
+                ":modified": Decimal(str(modified_timestamp)),
+                ":name": collection_name,
+                ":user_id": user_id,
+                ":count_delta": count_delta,
+                ":usage_delta": usage_delta,
+            },
+        )
+
         return obj
 
     def delete_storage_object(self, user_id: str, collection_name: str, object_id: str) -> float:

--- a/lambda/tests/services/test_storage_manager.py
+++ b/lambda/tests/services/test_storage_manager.py
@@ -785,6 +785,9 @@ class TestStorageManager:
             },
         )
 
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
+
         updated_obj = storage_manager.update_storage_object(
             "test-user-123", "bookmarks", "obj123", payload="new_payload"
         )
@@ -816,6 +819,9 @@ class TestStorageManager:
             {},
             None,  # Don't validate params
         )
+
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
 
         obj = storage_manager.update_storage_object(
             "test-user-123", "bookmarks", "nonexistent", payload="new"
@@ -1233,6 +1239,9 @@ class TestStorageManager:
             None,  # Don't validate params due to dynamic expiry field
         )
 
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
+
         updated_obj = storage_manager.update_storage_object(
             "test-user-123", "bookmarks", "obj123", payload="new_payload", sortindex=150, ttl=7200
         )
@@ -1505,6 +1514,9 @@ class TestStorageManager:
             None,
         )
 
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
+
         updated_obj = storage_manager.update_storage_object("test-user-123", "bookmarks", "obj123")
 
         assert updated_obj.ttl == 3600
@@ -1546,6 +1558,9 @@ class TestStorageManager:
             {},
             None,
         )
+
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
 
         updated_obj = storage_manager.update_storage_object("test-user-123", "bookmarks", "obj123")
 
@@ -1641,6 +1656,9 @@ class TestStorageManager:
             },
         )
 
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
+
         updated_obj = storage_manager.update_storage_object(
             "test-user-123", "bookmarks", "obj123", sortindex=200
         )
@@ -1686,6 +1704,9 @@ class TestStorageManager:
             {},
             None,
         )
+
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
 
         updated_obj = storage_manager.update_storage_object(
             "test-user-123", "bookmarks", "obj123", payload="updated_payload"
@@ -1742,6 +1763,9 @@ class TestStorageManager:
                 },
             },
         )
+
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
 
         updated_obj = storage_manager.update_storage_object("test-user-123", "bookmarks", "obj123")
 
@@ -2610,6 +2634,9 @@ class TestStorageManager:
 
         # Stub put_item for update
         dynamodb_stubber.add_response("put_item", {}, None)
+
+        # Stub update_item for collection metadata upsert
+        dynamodb_stubber.add_response("update_item", {}, None)
 
         obj = storage_manager.update_storage_object(
             "test-user-123",


### PR DESCRIPTION
## Summary

- `update_storage_object` (called by `PUT /storage/{collection}/{id}`) now creates or updates the collection METADATA record in DynamoDB after writing the BSO
- If the collection metadata already exists, atomically updates `modified`, `count`, and `usage`
- If the collection doesn't exist yet, creates a new METADATA record with proper GSI attributes

## Context

After the request/response format fix (#234), Firefox successfully PUTs `meta/global` and `crypto/keys`. However, when it then calls `GET /info/collections` to verify, the response is `{}` because no collection METADATA records were created. Firefox treats this as:

```
Consistency failure: info/collections excludes crypto after successful upload.
Symmetric key upload failed.
```

The batch POST endpoint (`create_or_update_collection`) correctly managed METADATA records, but the single-BSO PUT path (`update_storage_object`) never did.

## Test plan

- [x] All 924 tests pass with 100% coverage
- [x] Added DynamoDB stubber responses for collection metadata calls in all 9 affected `update_storage_object` tests
- [ ] Verify Firefox sync completes initial setup (meta/global + crypto/keys + info/collections check)