### PR TITLE
fix: include query string in Hawk MAC verification path

### DIFF
--- a/lambda/src/entrypoint/hawk_authorizer.py
+++ b/lambda/src/entrypoint/hawk_authorizer.py
@@ -78,7 +78,12 @@ def lambda_handler(
 
         # Extract request details using typed properties
         method = authorizer_event.http_method
+        # Hawk MAC must be computed over the full resource URI including query string
         path = authorizer_event.path
+        query_params = (event.get("queryStringParameters") or {}) or None
+        if query_params:
+            qs = "&".join(f"{k}={v}" for k, v in sorted(query_params.items()))
+            path = f"{path}?{qs}"
         domain_name = (
             authorizer_event.request_context.domain_name if authorizer_event.request_context else ""
         )

--- a/lambda/tests/entrypoint/test_hawk_authorizer.py
+++ b/lambda/tests/entrypoint/test_hawk_authorizer.py
@@ -187,6 +187,45 @@ class TestLambdaHandlerSuccess:
 
         assert result["principalId"] == "user123"
 
+    def test_lambda_handler_includes_query_string_in_path(
+        self,
+        authorizer_event,
+        lambda_context,
+        mock_service_provider,
+        token_cache_stubber,
+        valid_hawk_id,
+    ):
+        """Test that query string parameters are included in the path for MAC verification"""
+        authorizer_event["queryStringParameters"] = {"batch": "true", "commit": "true"}
+        authorizer_event["httpMethod"] = "POST"
+
+        token_cache_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
+                    "hawk_key": {"S": "a" * 64},
+                    "user_id": {"S": "user123"},
+                    "generation": {"N": "5"},
+                    "expiry": {"N": str(int(time.time()) + 300)},
+                    "created_at": {"N": str(int(time.time()))},
+                }
+            },
+            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
+        )
+
+        # Capture the path passed to verify_mac
+        mock_service_provider.hawk_service.verify_mac = MagicMock(return_value=True)
+        result = lambda_handler(authorizer_event, lambda_context, mock_service_provider)
+
+        assert result["principalId"] == "user123"
+        # Verify that verify_mac was called with path including query string
+        call_args = mock_service_provider.hawk_service.verify_mac.call_args
+        uri_arg = call_args[0][5]  # 6th positional arg is uri
+        assert "?" in uri_arg
+        assert "batch=true" in uri_arg
+        assert "commit=true" in uri_arg
+
 
 class TestLambdaHandlerAuthenticationFailures:
     """Tests for authentication failures"""


### PR DESCRIPTION
## Summary

- Reconstruct full URI (path + query string) in the Hawk authorizer before passing to MAC verification
- Query parameters are sorted for deterministic ordering

## Context

Firefox computes the Hawk MAC over the full resource URI including query parameters (e.g., `/1.5/{uid}/storage/clients?batch=true&commit=true`), but the authorizer was using only `authorizer_event.path` which excludes the query string. This caused MAC mismatch → 401 on any request with query parameters, specifically blocking the batch POST used by the clients engine sync.

## Test plan

- [x] 925 tests pass, 100% coverage
- [x] New test verifies query string is included in the path passed to `verify_mac`
- [ ] Verify Firefox batch POST to `/storage/clients?batch=true&commit=true` succeeds