### PR TITLE
fix: add X-Last-Modified header to all mutating storage responses

### DIFF
--- a/lambda/src/routes/bso/delete.py
+++ b/lambda/src/routes/bso/delete.py
@@ -55,6 +55,7 @@ class DeleteBSORoute(BaseRoute):
                 status_code=200,
                 content_type="application/json",
                 body=json_dumps(response_body),
+                headers={"X-Last-Modified": str(round(modified_timestamp, 2))},
             )
 
         except ValidationException as e:

--- a/lambda/src/routes/bso/update.py
+++ b/lambda/src/routes/bso/update.py
@@ -124,6 +124,7 @@ class UpdateBSORoute(BaseRoute):
                 status_code=200,
                 content_type="application/json",
                 body=json_dumps(modified),
+                headers={"X-Last-Modified": str(round(modified, 2))},
             )
 
         except ValidationException as e:

--- a/lambda/src/routes/collections/create.py
+++ b/lambda/src/routes/collections/create.py
@@ -132,8 +132,9 @@ class CreateCollectionRoute(BaseRoute):
 
             # Return Mozilla-compliant response format (Requirement 3.2)
             # {"modified": timestamp, "success": [...], "failed": {...}}
+            modified_ts = collection_data.modified.timestamp()
             response_body = {
-                "modified": collection_data.modified.timestamp(),
+                "modified": modified_ts,
                 "success": batch_result.success,
                 "failed": batch_result.failed,
             }
@@ -142,6 +143,7 @@ class CreateCollectionRoute(BaseRoute):
                 status_code=201,  # 201 Created for new collection
                 content_type="application/json",
                 body=json_dumps(response_body),
+                headers={"X-Last-Modified": str(round(modified_ts, 2))},
             )
 
         except ServerLimitExceededException:

--- a/lambda/src/routes/collections/delete.py
+++ b/lambda/src/routes/collections/delete.py
@@ -60,6 +60,7 @@ class DeleteCollectionRoute(BaseRoute):
                 status_code=200,
                 content_type="application/json",
                 body=json_dumps(response_body),
+                headers={"X-Last-Modified": str(round(modified_timestamp, 2))},
             )
 
         except ValidationException as e:

--- a/lambda/src/routes/collections/update.py
+++ b/lambda/src/routes/collections/update.py
@@ -94,8 +94,9 @@ class UpdateCollectionRoute(BaseRoute):
 
             # Return Mozilla-compliant response format
             # {"modified": timestamp, "success": [...], "failed": {...}}
+            modified_ts = collection_data.modified.timestamp()
             response_body = {
-                "modified": collection_data.modified.timestamp(),
+                "modified": modified_ts,
                 "success": batch_result.success,
                 "failed": batch_result.failed,
             }
@@ -104,6 +105,7 @@ class UpdateCollectionRoute(BaseRoute):
                 status_code=200,
                 content_type="application/json",
                 body=json_dumps(response_body),
+                headers={"X-Last-Modified": str(round(modified_ts, 2))},
             )
 
         except ValidationException as e:

--- a/lambda/src/routes/storage/delete_all.py
+++ b/lambda/src/routes/storage/delete_all.py
@@ -36,6 +36,7 @@ class DeleteAllStorageRoute(BaseRoute):
                 status_code=200,
                 content_type="application/json",
                 body=json_dumps({"modified": modified_timestamp}),
+                headers={"X-Last-Modified": str(round(modified_timestamp, 2))},
             )
 
         except Exception as e:

--- a/lambda/src/routes/storage/delete_root.py
+++ b/lambda/src/routes/storage/delete_root.py
@@ -38,6 +38,7 @@ class DeleteAllRootRoute(BaseRoute):
                 status_code=200,
                 content_type="application/json",
                 body=json_dumps(response_body),
+                headers={"X-Last-Modified": str(round(modified_timestamp, 2))},
             )
 
         except Exception as e:


### PR DESCRIPTION
## Summary

- Add `X-Last-Modified` response header to all mutating storage endpoints (POST, PUT, DELETE)
- Remove `sorted()` from query parameter reconstruction in Hawk authorizer — sorting reorders params vs what the client sent, causing MAC mismatch

## Context

**Tabs NaN (commit 1):** Per the SyncStorage API v1.5 spec, all mutating operations must return `X-Last-Modified`. The Rust tabs engine reads the modified timestamp from this header. Without it, `undefined` becomes `NaN`:
```
tabs failed: TypeError: newTimestamp: NaN exceeds the safe integer bounds
```

**Hawk query string ordering (commit 2):** The `sorted()` call reordered query parameters alphabetically (e.g., `?full=1&limit=1000&newer=...`) but Firefox sent them as `?newer=...&full=1&limit=1000`. Different URI string = different MAC = 401 on any GET with multiple query parameters:
```
GET fail 401 /storage/tabs?newer=1772129155.08&full=1&limit=1000
```

## Test plan

- [x] 925 tests pass, 100% coverage
- [ ] Verify tabs engine sync completes without NaN error
- [ ] Verify GET with multiple query params (newer, full, limit) passes Hawk auth