### PR TITLE
fix: preserve query parameter order in Hawk URI reconstruction

### DIFF
--- a/lambda/src/entrypoint/hawk_authorizer.py
+++ b/lambda/src/entrypoint/hawk_authorizer.py
@@ -82,7 +82,7 @@ def lambda_handler(
         path = authorizer_event.path
         query_params = (event.get("queryStringParameters") or {}) or None
         if query_params:
-            qs = "&".join(f"{k}={v}" for k, v in sorted(query_params.items()))
+            qs = "&".join(f"{k}={v}" for k, v in query_params.items())
             path = f"{path}?{qs}"
         domain_name = (
             authorizer_event.request_context.domain_name if authorizer_event.request_context else ""


### PR DESCRIPTION
## Summary

Remove `sorted()` from query parameter reconstruction in the Hawk authorizer.

## Context

`sorted()` reorders params alphabetically. Firefox sends `?newer=...&full=1&limit=1000` but we reconstructed `?full=1&limit=1000&newer=...`. Different URI = different MAC = 401 on any GET with multiple query parameters, blocking the tabs engine sync:

```
GET fail 401 /storage/tabs?newer=1772129155.08&full=1&limit=1000
```

## Test plan

- [x] 925 tests pass, 100% coverage
- [ ] Verify tabs GET with multiple query params passes Hawk auth