### PR TITLE
refactor: replace custom Hawk auth with mohawk library

### DIFF
--- a/frontend/src/lib/fxa-crypto.ts
+++ b/frontend/src/lib/fxa-crypto.ts
@@ -54,7 +54,7 @@ export async function buildHawkHeaderWithInfo(
   const derived = await hkdf(tokenBytes.buffer, infoString, 96)
 
   const tokenId = toHex(derived.slice(0, 32))
-  const reqHMACKey = derived.slice(32, 64)
+  const reqHMACKeyHex = toHex(derived.slice(32, 64))
 
   const parsedUrl = new URL(url)
   const host = parsedUrl.hostname
@@ -69,7 +69,7 @@ export async function buildHawkHeaderWithInfo(
 
   const key = await crypto.subtle.importKey(
     "raw",
-    reqHMACKey,
+    encode(reqHMACKeyHex),
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign"]

--- a/lambda/pyproject.toml
+++ b/lambda/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "boto3==1.42.57",
     "cryptography==46.0.5",
     "dataclasses-json==0.6.7",
+    "mohawk==1.1.0",
     "PyJWT==2.11.0",
     "requests==2.32.5"
 ]

--- a/lambda/src/services/fxa_token_manager.py
+++ b/lambda/src/services/fxa_token_manager.py
@@ -1,12 +1,10 @@
 """FxA Token Manager for session tokens and key-fetch tokens in DynamoDB"""
 
-import base64
-import hashlib
-import hmac
-import re
 import time
 from typing import Optional
 
+import mohawk
+import mohawk.exc
 from botocore.exceptions import ClientError
 
 from src.services import fxa_crypto
@@ -17,11 +15,6 @@ KEY_FETCH_TOKEN_INFO = "identity.mozilla.com/picl/v1/keyFetchToken"
 
 SESSION_PREFIX = "SESSION"
 KEYFETCH_PREFIX = "KEYFETCH"
-
-HAWK_HEADER_PATTERN = re.compile(
-    r'id="(?P<id>[^"]+)".*ts="(?P<ts>[^"]+)".*nonce="(?P<nonce>[^"]+)"'
-    r'(?:.*hash="(?P<hash>[^"]+)")?.*mac="(?P<mac>[^"]+)"'
-)
 
 
 class FxATokenManager:
@@ -106,6 +99,49 @@ class FxATokenManager:
 
         return item["uid"]
 
+    def _seen_nonce(self, sender_id, nonce, timestamp):
+        """Check if a nonce has been seen before (replay protection).
+
+        Uses DynamoDB conditional write: if the nonce record already exists,
+        the request is a replay. Records auto-expire via DynamoDB TTL.
+        """
+        try:
+            self.table.put_item(
+                Item={
+                    _PK: f"NONCE#{sender_id}#{nonce}#{timestamp}",
+                    "expiry": int(time.time()) + 120,
+                },
+                ConditionExpression=f"attribute_not_exists({_PK})",
+            )
+            return False  # New nonce
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return True  # Replay detected
+            raise
+
+    def _verify_hawk(self, authorization_header, method, path, host, port, credentials_map):
+        """Verify Hawk signature using mohawk.Receiver.
+
+        Returns True on success, False on any authentication failure.
+        The credentials_map callback handles credential lookup and may
+        populate external state (e.g. uid) via closure side effects.
+        """
+        if not authorization_header:
+            return False
+        try:
+            mohawk.Receiver(
+                credentials_map,
+                authorization_header,
+                f"https://{host}:{port}{path}",
+                method,
+                seen_nonce=self._seen_nonce,
+                accept_untrusted_content=True,
+                timestamp_skew_in_seconds=60,
+            )
+            return True
+        except mohawk.exc.HawkFail:
+            return False
+
     def verify_session_hawk(
         self,
         authorization_header: str,
@@ -114,67 +150,25 @@ class FxATokenManager:
         host: str,
         port: str,
     ) -> Optional[str]:
-        """Verify Hawk HMAC signature for session-authenticated routes.
+        """Verify Hawk HMAC signature for session-authenticated routes."""
+        uid_holder = {}
 
-        1. Parse Hawk header fields (id, ts, nonce, mac)
-        2. Look up SESSION#{id} to get uid and reqHMACkey
-        3. Check expiry
-        4. Construct canonical string
-        5. Compute HMAC-SHA256(reqHMACkey, canonical_string)
-        6. Constant-time compare with provided mac
-        7. Return uid on success, None on failure
+        def credentials_map(sender_id):
+            response = self.table.get_item(Key={_PK: f"{SESSION_PREFIX}#{sender_id}"})
+            if "Item" not in response:
+                raise mohawk.exc.CredentialsLookupError("Session not found")
+            item = response["Item"]
+            if item.get("expiry", 0) < int(time.time()):
+                raise mohawk.exc.CredentialsLookupError("Session expired")
+            key = item.get("reqHMACkey")
+            if not key:
+                raise mohawk.exc.CredentialsLookupError("Missing HMAC key")
+            uid_holder["uid"] = item["uid"]
+            return {"id": sender_id, "key": key, "algorithm": "sha256"}
 
-        Args:
-            authorization_header: Full Authorization header value
-            method: HTTP method (GET, POST, etc.)
-            path: Request path
-            host: Request host
-            port: Request port
-
-        Returns:
-            uid on success, None on failure
-        """
-        match = HAWK_HEADER_PATTERN.search(authorization_header)
-        if not match:
+        if not self._verify_hawk(authorization_header, method, path, host, port, credentials_map):
             return None
-
-        token_id_hex = match.group("id")
-        ts = match.group("ts")
-        nonce = match.group("nonce")
-        mac_b64 = match.group("mac")
-
-        # Look up session record
-        response = self.table.get_item(Key={_PK: f"{SESSION_PREFIX}#{token_id_hex}"})
-        if "Item" not in response:
-            return None
-
-        item = response["Item"]
-
-        # Check expiry
-        if item.get("expiry", 0) < int(time.time()):
-            return None
-
-        req_hmac_key_hex = item.get("reqHMACkey")
-        if not req_hmac_key_hex:
-            return None
-
-        req_hmac_key = bytes.fromhex(req_hmac_key_hex)
-
-        # Construct canonical string per Hawk spec
-        payload_hash = match.group("hash") or ""
-        canonical = (
-            f"hawk.1.header\n{ts}\n{nonce}\n{method}\n{path}\n{host}\n{port}\n{payload_hash}\n\n"
-        )
-
-        # Compute expected MAC
-        computed_mac = hmac.new(req_hmac_key, canonical.encode("ascii"), hashlib.sha256).digest()
-        computed_mac_b64 = base64.b64encode(computed_mac).decode("ascii")
-
-        # Constant-time compare
-        if not hmac.compare_digest(computed_mac_b64, mac_b64):
-            return None
-
-        return item["uid"]
+        return uid_holder.get("uid")
 
     def verify_keyfetch_hawk(
         self,
@@ -188,69 +182,41 @@ class FxATokenManager:
 
         Atomically consumes the key-fetch token (single-use) while verifying
         the Hawk HMAC signature.
-
-        Args:
-            authorization_header: Full Authorization header value
-            method: HTTP method (GET, POST, etc.)
-            path: Request path
-            host: Request host
-            port: Request port
-
-        Returns:
-            Dict with uid and keyFetchToken on success, None on failure
         """
-        match = HAWK_HEADER_PATTERN.search(authorization_header)
-        if not match:
+        result_holder = {}
+
+        def credentials_map(sender_id):
+            try:
+                response = self.table.delete_item(
+                    Key={_PK: f"{KEYFETCH_PREFIX}#{sender_id}"},
+                    ReturnValues="ALL_OLD",
+                    ConditionExpression="attribute_exists(PK)",
+                )
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                    raise mohawk.exc.CredentialsLookupError("Token not found")
+                raise
+            item = response.get("Attributes")
+            if not item:
+                raise mohawk.exc.CredentialsLookupError("Token not found")
+            if item.get("expiry", 0) < int(time.time()):
+                raise mohawk.exc.CredentialsLookupError("Token expired")
+            key = item.get("reqHMACkey")
+            if not key:
+                raise mohawk.exc.CredentialsLookupError("Missing HMAC key")
+            result_holder["uid"] = item["uid"]
+            result_holder["keyFetchToken"] = item["keyFetchToken"]
+            return {"id": sender_id, "key": key, "algorithm": "sha256"}
+
+        if not self._verify_hawk(authorization_header, method, path, host, port, credentials_map):
             return None
 
-        token_id_hex = match.group("id")
-        ts = match.group("ts")
-        nonce = match.group("nonce")
-        mac_b64 = match.group("mac")
-
-        # Atomically consume the key-fetch token
-        try:
-            response = self.table.delete_item(
-                Key={_PK: f"{KEYFETCH_PREFIX}#{token_id_hex}"},
-                ReturnValues="ALL_OLD",
-                ConditionExpression="attribute_exists(PK)",
-            )
-        except ClientError as e:
-            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                return None
-            raise
-
-        item = response.get("Attributes")
-        if not item:
-            return None
-
-        # Check expiry
-        if item.get("expiry", 0) < int(time.time()):
-            return None
-
-        req_hmac_key_hex = item.get("reqHMACkey")
-        if not req_hmac_key_hex:
-            return None
-
-        req_hmac_key = bytes.fromhex(req_hmac_key_hex)
-
-        # Construct canonical string per Hawk spec
-        payload_hash = match.group("hash") or ""
-        canonical = (
-            f"hawk.1.header\n{ts}\n{nonce}\n{method}\n{path}\n{host}\n{port}\n{payload_hash}\n\n"
-        )
-
-        # Compute expected MAC
-        computed_mac = hmac.new(req_hmac_key, canonical.encode("ascii"), hashlib.sha256).digest()
-        computed_mac_b64 = base64.b64encode(computed_mac).decode("ascii")
-
-        # Constant-time compare
-        if not hmac.compare_digest(computed_mac_b64, mac_b64):
+        if "uid" not in result_holder:
             return None
 
         return {
-            "uid": item["uid"],
-            "keyFetchToken": item["keyFetchToken"],
+            "uid": result_holder["uid"],
+            "keyFetchToken": result_holder["keyFetchToken"],
         }
 
     def create_key_fetch_token(self, uid: str) -> bytes:

--- a/lambda/src/services/hawk_service.py
+++ b/lambda/src/services/hawk_service.py
@@ -2,17 +2,19 @@
 HAWK Authentication Service
 
 Unified service for HAWK credential generation (Token Server) and validation (Storage Server).
+Uses mohawk library for Hawk protocol validation.
 """
 
 import base64
 import binascii
-import hashlib
-import hmac
+import re
 import secrets
 import time
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+import mohawk
+import mohawk.exc
 from aws_lambda_powertools import Logger
 from botocore.exceptions import ClientError
 
@@ -25,6 +27,9 @@ from src.shared.exceptions import (
 )
 
 logger = Logger(child=True)
+
+# Pattern to extract hawk id from header without full parse
+_HAWK_ID_PATTERN = re.compile(r'id="([^"]+)"')
 
 
 @dataclass
@@ -48,20 +53,11 @@ class HawkService:
 
     Storage Server uses:
         - validate()
-        - All validation helper methods
     """
 
     def __init__(
         self, token_cache_table, timestamp_skew_tolerance: int = 60, token_duration: int = 300
     ):
-        """
-        Initialize HAWK service with DynamoDB table.
-
-        Args:
-            token_cache_table: boto3 DynamoDB Table resource for token cache
-            timestamp_skew_tolerance: Allowed clock skew in seconds
-            token_duration: Duration a token is valid for
-        """
         self.token_cache_table = token_cache_table
         self.timestamp_skew_tolerance = timestamp_skew_tolerance
         self.token_duration = token_duration
@@ -72,302 +68,120 @@ class HawkService:
         """
         Validate HAWK Authorization header and return credentials.
 
-        Args:
-            authorization_header: HAWK Authorization header value
-            method: HTTP method (GET, POST, etc.)
-            path: Request path
-            host: Request host
-            port: Request port
-
-        Returns:
-            HawkCredentials with user_id, generation, expiry, hawk_id
-
-        Raises:
-            InvalidHawkHeaderException: Malformed HAWK header
-            ExpiredHawkTokenException: Token expired
-            InvalidHawkSignatureException: Signature verification failed
-            InvalidGenerationException: Generation number mismatch
-
-        HAWK Header Format:
-            Hawk id="base64_encoded_id", ts="1702345678", nonce="random", mac="signature"
-
-        HAWK ID Format (base64-encoded):
-            {user_id}:{generation}:{expiry_timestamp}
-
-        Validation Steps:
-            1. Parse HAWK header and extract id, ts, nonce, mac, hash (optional)
-            2. Decode HAWK ID and extract user_id, generation, expiry
-            3. Verify token has not expired (current_time < expiry)
-            4. Validate timestamp is within acceptable window
-            5. Retrieve HAWK shared secret from TokenKeyStore
-            6. Compute expected MAC using HMAC-SHA256
-            7. Compare computed MAC with provided MAC (constant-time comparison)
+        Uses mohawk.Receiver for header parsing, timestamp validation, and MAC verification.
+        Custom business logic (expiry, generation) runs in the credentials_map callback.
         """
-        # Parse HAWK header
-        hawk_params = self.parse_hawk_header(authorization_header)
-        hawk_id = hawk_params["id"]
-        timestamp = int(hawk_params["ts"])
-        nonce = hawk_params["nonce"]
-        provided_mac = hawk_params["mac"]
-        payload_hash = hawk_params.get("hash", "")  # Extract hash if present
-        ext = hawk_params.get("ext", "")
-
-        # Decode and validate HAWK ID
+        # Extract hawk_id for pre-validation of custom business logic
+        hawk_id = self._extract_hawk_id(authorization_header)
         user_id, generation, expiry = self.decode_hawk_id(hawk_id)
 
-        # Validate token hasn't expired
+        # Validate token hasn't expired (custom check, not part of Hawk protocol)
         if not self.validate_hawk_id_expiry(expiry):
             raise ExpiredHawkTokenException(f"HAWK token expired at {expiry}")
 
-        # Validate timestamp
-        if not self.validate_timestamp(timestamp):
-            raise InvalidHawkSignatureException(f"Timestamp {timestamp} outside acceptable window")
+        # Credentials lookup called by mohawk during MAC verification
+        def credentials_map(sender_id):
+            hawk_key, cached_user_id, cached_generation = self.get_hawk_key_from_cache(sender_id)
+            if cached_generation != generation:
+                raise InvalidGenerationException(
+                    f"Generation mismatch: expected {cached_generation}, got {generation}"
+                )
+            return {"id": sender_id, "key": hawk_key, "algorithm": "sha256"}
 
-        # Retrieve HAWK key from cache
-        hawk_key, cached_user_id, cached_generation = self.get_hawk_key_from_cache(hawk_id)
-
-        # Verify generation matches
-        if cached_generation != generation:
-            raise InvalidGenerationException(
-                f"Generation mismatch: expected {cached_generation}, got {generation}"
+        # mohawk handles: header parsing, timestamp skew, normalized string, MAC verification
+        try:
+            mohawk.Receiver(
+                credentials_map,
+                authorization_header,
+                f"https://{host}:{port}{path}",
+                method,
+                seen_nonce=self._seen_nonce,
+                timestamp_skew_in_seconds=self.timestamp_skew_tolerance,
+                accept_untrusted_content=True,
             )
-
-        # Verify MAC (now including payload_hash and ext)
-        if not self.verify_mac(
-            hawk_key, provided_mac, timestamp, nonce, method, path, host, port, payload_hash, ext
-        ):
+        except (InvalidGenerationException, AuthenticationException):
+            raise
+        except mohawk.exc.MissingAuthorization:
+            raise InvalidHawkHeaderException("Missing authorization header")
+        except mohawk.exc.BadHeaderValue as e:
+            raise InvalidHawkHeaderException(str(e))
+        except mohawk.exc.MacMismatch:
             raise InvalidHawkSignatureException("HAWK MAC verification failed")
+        except mohawk.exc.TokenExpired:
+            raise InvalidHawkSignatureException("Timestamp outside acceptable window")
+        except mohawk.exc.HawkFail as e:
+            raise InvalidHawkSignatureException(str(e))
+
+        logger.info(
+            "HAWK authentication successful",
+            extra={
+                "method": method,
+                "uri": path,
+                "host": host,
+                "port": port,
+            },
+        )
 
         return HawkCredentials(
             user_id=user_id, generation=generation, expiry=expiry, hawk_id=hawk_id
         )
 
-    def parse_hawk_header(self, authorization_header: str) -> dict:
-        """
-        Parse HAWK Authorization header.
+    def _seen_nonce(self, sender_id, nonce, timestamp):
+        """Check if a nonce has been seen before (replay protection).
 
-        Args:
-            authorization_header: Full Authorization header value
-
-        Returns:
-            Dictionary with id, ts, nonce, mac keys
-
-        Raises:
-            InvalidHawkHeaderException: Malformed header
-
-        Example:
-            Hawk id="abc123", ts="1702345678", nonce="xyz", mac="signature=="
-        """
-        if not authorization_header.startswith("Hawk "):
-            raise InvalidHawkHeaderException("Authorization header must start with 'Hawk '")
-
-        # Parse key="value" pairs
-        params = {}
-        parts = authorization_header[5:].split(", ")  # Skip 'Hawk '
-        for part in parts:
-            if "=" not in part:
-                raise InvalidHawkHeaderException(f"Invalid HAWK parameter: {part}")
-            key, value = part.split("=", 1)
-            params[key] = value.strip('"')
-
-        # Validate required fields
-        required = ["id", "ts", "nonce", "mac"]
-        for field in required:
-            if field not in params:
-                raise InvalidHawkHeaderException(f"Missing required HAWK parameter: {field}")
-
-        return params
-
-    def decode_hawk_id(self, hawk_id: str) -> Tuple[str, int, int]:
-        """
-        Decode HAWK ID back to user_id, generation, expiry.
-
-        Args:
-            hawk_id: Base64-encoded HAWK ID
-
-        Returns:
-            Tuple of (user_id, generation, expiry)
-
-        Raises:
-            InvalidHawkHeaderException: Invalid format
+        Uses DynamoDB conditional write: if the nonce record already exists,
+        the request is a replay. Records auto-expire via DynamoDB TTL.
         """
         try:
-            # Add padding back if needed
+            self.token_cache_table.put_item(
+                Item={
+                    "PK": f"NONCE#{sender_id}#{nonce}#{timestamp}",
+                    "expiry": int(time.time()) + self.timestamp_skew_tolerance * 2,
+                },
+                ConditionExpression="attribute_not_exists(PK)",
+            )
+            return False  # New nonce
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return True  # Replay detected
+            raise
+
+    def _extract_hawk_id(self, authorization_header: str) -> str:
+        """Extract the id field from a Hawk Authorization header."""
+        if not authorization_header or not authorization_header.startswith("Hawk "):
+            raise InvalidHawkHeaderException("Authorization header must start with 'Hawk '")
+        match = _HAWK_ID_PATTERN.search(authorization_header)
+        if not match:
+            raise InvalidHawkHeaderException("Missing id in HAWK header")
+        return match.group(1)
+
+    def decode_hawk_id(self, hawk_id: str) -> Tuple[str, int, int]:
+        """Decode HAWK ID back to user_id, generation, expiry."""
+        try:
             padding = 4 - (len(hawk_id) % 4)
             if padding != 4:
                 hawk_id += "=" * padding
-
             decoded = base64.urlsafe_b64decode(hawk_id).decode("utf-8")
             parts = decoded.split(":")
-
             if len(parts) != 3:
                 raise ValueError("HAWK ID must have 3 parts")
-
             user_id, generation, expiry = parts
             return user_id, int(generation), int(expiry)
-
         except (ValueError, binascii.Error) as e:
             raise InvalidHawkHeaderException(f"Invalid HAWK ID format: {e}")
 
     def validate_hawk_id_expiry(self, expiry: int) -> bool:
-        """
-        Validate HAWK ID hasn't expired.
-
-        Args:
-            expiry: Unix timestamp when token expires
-
-        Returns:
-            True if token is still valid
-        """
+        """Validate HAWK ID hasn't expired."""
         return int(time.time()) < expiry
 
-    def validate_timestamp(self, timestamp: int) -> bool:
-        """
-        Validate timestamp is within acceptable window.
-
-        Args:
-            timestamp: Unix timestamp from HAWK header
-
-        Returns:
-            True if timestamp is within acceptable skew
-        """
-        now = int(time.time())
-        return abs(now - timestamp) <= self.timestamp_skew_tolerance
-
-    def build_normalized_string(
-        self,
-        timestamp: str,
-        nonce: str,
-        method: str,
-        uri: str,
-        host: str,
-        port: str,
-        payload_hash: str = "",
-        ext: str = "",
-    ) -> str:
-        """
-        Build the normalized request string for MAC calculation.
-
-        HAWK Normalized Request String Format:
-            hawk.1.header\n
-            {timestamp}\n
-            {nonce}\n
-            {method}\n
-            {uri}\n
-            {host}\n
-            {port}\n
-            {payload_hash}\n
-            {ext}\n
-        """
-        return (
-            f"hawk.1.header\n"
-            f"{timestamp}\n"
-            f"{nonce}\n"
-            f"{method.upper()}\n"
-            f"{uri}\n"
-            f"{host.lower()}\n"
-            f"{port}\n"
-            f"{payload_hash}\n"
-            f"{ext}\n"
-        )
-
-    def calculate_mac(self, key: str, normalized_string: str) -> str:
-        """
-        Calculate HAWK MAC using HMAC-SHA256.
-
-        Args:
-            key: HAWK shared secret (as string, NOT hex-encoded)
-            normalized_string: Normalized request string
-
-        Returns:
-            Base64-encoded MAC signature
-        """
-        # Use key as UTF-8 bytes directly (mohawk compatibility)
-        mac = hmac.new(key.encode("utf-8"), normalized_string.encode("utf-8"), hashlib.sha256)
-        return base64.b64encode(mac.digest()).decode("utf-8")
-
-    def verify_mac(
-        self,
-        hawk_key: str,
-        provided_mac: str,
-        timestamp: int,
-        nonce: str,
-        method: str,
-        uri: str,
-        host: str,
-        port: int,
-        payload_hash: str = "",
-        ext: str = "",
-    ) -> bool:
-        """
-        Verify the MAC from the Authorization header.
-
-        Args:
-            hawk_key: Hex-encoded HAWK shared secret
-            provided_mac: MAC from Authorization header
-            timestamp: Unix timestamp from header
-            nonce: Nonce from header
-            method: HTTP method
-            uri: Request URI
-            host: Request host
-            port: Request port
-            payload_hash: Optional payload hash
-            ext: Optional extension data
-
-        Returns:
-            True if MAC is valid (constant-time comparison)
-        """
-        normalized = self.build_normalized_string(
-            str(timestamp), nonce, method, uri, host, str(port), payload_hash, ext
-        )
-        expected_mac = self.calculate_mac(hawk_key, normalized)
-        match = hmac.compare_digest(expected_mac, provided_mac)
-
-        # Log MAC verification details for debugging
-        logger.info(
-            "HAWK MAC verification",
-            extra={
-                "method": method,
-                "uri": uri,
-                "host": host,
-                "port": port,
-                "timestamp": timestamp,
-                "match": match,
-            },
-        )
-
-        return match
-
     def get_hawk_key_from_cache(self, hawk_id: str) -> Tuple[str, str, int]:
-        """
-        Retrieve HAWK shared secret from token cache.
-
-        Args:
-            hawk_id: Base64-encoded HAWK ID
-
-        Returns:
-            Tuple of (hawk_key, user_id, generation)
-
-        Raises:
-            AuthenticationException: Token not found in cache or DynamoDB error
-
-        Token Cache Schema:
-            PK: "TOKEN#{base64_hawk_id}"
-            hawk_key: String (hex-encoded, 64 chars)
-            user_id: String
-            generation: Number
-            expiry: Number (DynamoDB TTL attribute for auto-cleanup)
-            created_at: Number
-        """
+        """Retrieve HAWK shared secret from token cache."""
         try:
             response = self.token_cache_table.get_item(Key={"PK": f"TOKEN#{hawk_id}"})
-
             if "Item" not in response:
                 raise AuthenticationException(f"HAWK token not found: {hawk_id}")
-
             item = response["Item"]
             return (item["hawk_key"], item["user_id"], int(item["generation"]))
-
         except ClientError as e:
             logger.error(f"Failed to retrieve HAWK token from cache: {e}")
             raise AuthenticationException(f"Failed to retrieve HAWK token: {e}")
@@ -375,22 +189,10 @@ class HawkService:
     # ========== Token Generation Methods (Token Server) ==========
 
     def generate_hawk_credentials(self, user_id: str, generation: int) -> HawkCredentials:
-        """
-        Generate HAWK credentials for token issuance.
-
-        Args:
-            user_id: User identifier from OIDC sub claim
-            generation: Current generation number
-
-        Returns:
-            HawkCredentials with hawk_id and hawk_key populated
-
-        Used by Token Server when issuing tokens.
-        """
+        """Generate HAWK credentials for token issuance."""
         expiry = int(time.time()) + self.token_duration
         hawk_id = self.generate_hawk_id(user_id, generation, expiry)
         hawk_key = self.generate_hawk_key()
-
         return HawkCredentials(
             user_id=user_id,
             generation=generation,
@@ -400,38 +202,17 @@ class HawkService:
         )
 
     def generate_hawk_id(self, user_id: str, generation: int, expiry: int) -> str:
-        """
-        Generate HAWK identifier (URL-safe base64).
-
-        Format: {user_id}:{generation}:{expiry}
-
-        Returns:
-            Base64-encoded HAWK ID (without padding)
-        """
+        """Generate HAWK identifier (URL-safe base64, no padding)."""
         id_string = f"{user_id}:{generation}:{expiry}"
         encoded = base64.urlsafe_b64encode(id_string.encode("utf-8")).decode("utf-8")
-        # Remove padding for cleaner URLs
         return encoded.rstrip("=")
 
     def generate_hawk_key(self) -> str:
-        """
-        Generate cryptographically random HAWK shared secret.
-
-        Returns:
-            64-character hex string (32 bytes of randomness, hex-encoded for storage)
-            Note: This hex string is used as-is by mohawk, not decoded
-        """
+        """Generate cryptographically random HAWK shared secret (64-char hex)."""
         return secrets.token_bytes(32).hex()
 
     def store_token_in_cache(self, credentials: HawkCredentials) -> None:
-        """
-        Store issued HAWK token in DynamoDB cache.
-
-        Args:
-            credentials: HawkCredentials with hawk_key populated
-
-        Used by Token Server after generating credentials.
-        """
+        """Store issued HAWK token in DynamoDB cache."""
         self.token_cache_table.put_item(
             Item={
                 "PK": f"TOKEN#{credentials.hawk_id}",

--- a/lambda/tests/entrypoint/test_hawk_authorizer.py
+++ b/lambda/tests/entrypoint/test_hawk_authorizer.py
@@ -5,9 +5,10 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-from botocore.stub import Stubber
+from botocore.stub import ANY, Stubber
 
 from src.entrypoint.hawk_authorizer import lambda_handler
+from tests.fixtures.integration import build_hawk_auth_header
 
 
 def generate_hawk_id(user_id: str, generation: int, expiry: int) -> str:
@@ -24,14 +25,24 @@ def valid_hawk_id():
 
 
 @pytest.fixture
+def hawk_key():
+    """Shared secret for HAWK authentication"""
+    return "a" * 64
+
+
+@pytest.fixture
 def current_timestamp():
     """Get current timestamp for HAWK header"""
     return str(int(time.time()))
 
 
 @pytest.fixture
-def authorizer_event(valid_hawk_id, current_timestamp):
-    """Create a sample API Gateway authorizer REQUEST event (Powertools format)"""
+def authorizer_event(valid_hawk_id, hawk_key):
+    """Create a sample API Gateway authorizer REQUEST event with valid Hawk header"""
+    # Build a valid Hawk header for the default path/method/host
+    auth_header = build_hawk_auth_header(
+        valid_hawk_id, hawk_key, "GET", "/1.5/12345/storage/bookmarks", "api.example.com", 443
+    )
     return {
         "version": "1.0",
         "type": "REQUEST",
@@ -41,9 +52,7 @@ def authorizer_event(valid_hawk_id, current_timestamp):
         "resource": "/1.5/12345/storage/bookmarks",
         "path": "/1.5/12345/storage/bookmarks",
         "httpMethod": "GET",
-        "headers": {
-            "Authorization": f'Hawk id="{valid_hawk_id}", ts="{current_timestamp}", nonce="abc123", mac="test_mac"'
-        },
+        "headers": {"Authorization": auth_header},
         "queryStringParameters": {},
         "pathParameters": {"uid": "12345"},
         "stageVariables": {},
@@ -72,6 +81,37 @@ def token_cache_stubber(boto_session):
         yield stubber
 
 
+def stub_token_cache(stubber, hawk_id, hawk_key, generation=5):
+    """Helper to add a token cache DynamoDB stub response"""
+    stubber.add_response(
+        "get_item",
+        {
+            "Item": {
+                "PK": {"S": f"TOKEN#{hawk_id}"},
+                "hawk_key": {"S": hawk_key},
+                "user_id": {"S": "user123"},
+                "generation": {"N": str(generation)},
+                "expiry": {"N": str(int(time.time()) + 300)},
+                "created_at": {"N": str(int(time.time()))},
+            }
+        },
+        {"Key": {"PK": f"TOKEN#{hawk_id}"}, "TableName": "test-token-cache-table"},
+    )
+
+
+def stub_nonce(stubber):
+    """Helper to add a nonce replay protection DynamoDB stub response"""
+    stubber.add_response(
+        "put_item",
+        {},
+        {
+            "TableName": "test-token-cache-table",
+            "Item": ANY,
+            "ConditionExpression": "attribute_not_exists(PK)",
+        },
+    )
+
+
 class TestLambdaHandlerSuccess:
     """Tests for successful authorization"""
 
@@ -82,28 +122,12 @@ class TestLambdaHandlerSuccess:
         mock_service_provider,
         token_cache_stubber,
         valid_hawk_id,
+        hawk_key,
     ):
         """Test successful HAWK authorization"""
-        # Stub DynamoDB get_item response
-        token_cache_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
-                    "hawk_key": {"S": "a" * 64},
-                    "user_id": {"S": "user123"},
-                    "generation": {"N": "5"},
-                    "expiry": {"N": str(int(time.time()) + 300)},
-                    "created_at": {"N": str(int(time.time()))},
-                }
-            },
-            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
-        )
+        stub_token_cache(token_cache_stubber, valid_hawk_id, hawk_key)
+        stub_nonce(token_cache_stubber)
 
-        # Mock verify_mac to return True (since tests use fake MAC values)
-        mock_service_provider.hawk_service.verify_mac = MagicMock(return_value=True)
-
-        # Use dependency injection - no patching needed!
         result = lambda_handler(authorizer_event, lambda_context, mock_service_provider)
 
         # Verify result structure
@@ -130,101 +154,94 @@ class TestLambdaHandlerSuccess:
         mock_service_provider,
         token_cache_stubber,
         valid_hawk_id,
+        hawk_key,
     ):
         """Test that validate is called with correct parameters"""
-        token_cache_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
-                    "hawk_key": {"S": "a" * 64},
-                    "user_id": {"S": "user123"},
-                    "generation": {"N": "5"},
-                    "expiry": {"N": str(int(time.time()) + 300)},
-                    "created_at": {"N": str(int(time.time()))},
-                }
-            },
-            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
-        )
+        stub_token_cache(token_cache_stubber, valid_hawk_id, hawk_key)
+        stub_nonce(token_cache_stubber)
 
-        mock_service_provider.hawk_service.verify_mac = MagicMock(return_value=True)
         result = lambda_handler(authorizer_event, lambda_context, mock_service_provider)
 
         assert result["principalId"] == "user123"
 
     def test_lambda_handler_case_insensitive_authorization_header(
         self,
-        authorizer_event,
         lambda_context,
         mock_service_provider,
         token_cache_stubber,
         valid_hawk_id,
-        current_timestamp,
+        hawk_key,
     ):
         """Test that Authorization header is case-insensitive (Powertools feature)"""
-        # Use lowercase 'authorization' header
-        authorizer_event["headers"] = {
-            "authorization": f'Hawk id="{valid_hawk_id}", ts="{current_timestamp}", nonce="abc123", mac="test_mac"'
+        # Build a fresh event with lowercase 'authorization' header
+        auth_header = build_hawk_auth_header(
+            valid_hawk_id, hawk_key, "GET", "/1.5/12345/storage/bookmarks", "api.example.com", 443
+        )
+        event = {
+            "version": "1.0",
+            "type": "REQUEST",
+            "methodArn": "arn:aws:execute-api:us-east-1:123456789012:abcdef123/prod/GET/storage/bookmarks",
+            "identitySource": "",
+            "authorizationToken": "",
+            "resource": "/1.5/12345/storage/bookmarks",
+            "path": "/1.5/12345/storage/bookmarks",
+            "httpMethod": "GET",
+            "headers": {"authorization": auth_header},
+            "queryStringParameters": {},
+            "pathParameters": {"uid": "12345"},
+            "stageVariables": {},
+            "requestContext": {
+                "domainName": "api.example.com",
+                "accountId": "123456789012",
+            },
         }
 
-        token_cache_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
-                    "hawk_key": {"S": "a" * 64},
-                    "user_id": {"S": "user123"},
-                    "generation": {"N": "5"},
-                    "expiry": {"N": str(int(time.time()) + 300)},
-                    "created_at": {"N": str(int(time.time()))},
-                }
-            },
-            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
-        )
+        stub_token_cache(token_cache_stubber, valid_hawk_id, hawk_key)
+        stub_nonce(token_cache_stubber)
 
-        mock_service_provider.hawk_service.verify_mac = MagicMock(return_value=True)
-        result = lambda_handler(authorizer_event, lambda_context, mock_service_provider)
+        result = lambda_handler(event, lambda_context, mock_service_provider)
 
         assert result["principalId"] == "user123"
 
     def test_lambda_handler_includes_query_string_in_path(
         self,
-        authorizer_event,
         lambda_context,
         mock_service_provider,
         token_cache_stubber,
         valid_hawk_id,
+        hawk_key,
     ):
         """Test that query string parameters are included in the path for MAC verification"""
-        authorizer_event["queryStringParameters"] = {"batch": "true", "commit": "true"}
-        authorizer_event["httpMethod"] = "POST"
-
-        token_cache_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
-                    "hawk_key": {"S": "a" * 64},
-                    "user_id": {"S": "user123"},
-                    "generation": {"N": "5"},
-                    "expiry": {"N": str(int(time.time()) + 300)},
-                    "created_at": {"N": str(int(time.time()))},
-                }
-            },
-            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
+        # Build header with query string included in the path
+        path_with_qs = "/1.5/12345/storage/bookmarks?batch=true&commit=true"
+        auth_header = build_hawk_auth_header(
+            valid_hawk_id, hawk_key, "POST", path_with_qs, "api.example.com", 443
         )
+        event = {
+            "version": "1.0",
+            "type": "REQUEST",
+            "methodArn": "arn:aws:execute-api:us-east-1:123456789012:abcdef123/prod/POST/storage/bookmarks",
+            "identitySource": "",
+            "authorizationToken": "",
+            "resource": "/1.5/12345/storage/bookmarks",
+            "path": "/1.5/12345/storage/bookmarks",
+            "httpMethod": "POST",
+            "headers": {"Authorization": auth_header},
+            "queryStringParameters": {"batch": "true", "commit": "true"},
+            "pathParameters": {"uid": "12345"},
+            "stageVariables": {},
+            "requestContext": {
+                "domainName": "api.example.com",
+                "accountId": "123456789012",
+            },
+        }
 
-        # Capture the path passed to verify_mac
-        mock_service_provider.hawk_service.verify_mac = MagicMock(return_value=True)
-        result = lambda_handler(authorizer_event, lambda_context, mock_service_provider)
+        stub_token_cache(token_cache_stubber, valid_hawk_id, hawk_key)
+        stub_nonce(token_cache_stubber)
+
+        result = lambda_handler(event, lambda_context, mock_service_provider)
 
         assert result["principalId"] == "user123"
-        # Verify that verify_mac was called with path including query string
-        call_args = mock_service_provider.hawk_service.verify_mac.call_args
-        uri_arg = call_args[0][5]  # 6th positional arg is uri
-        assert "?" in uri_arg
-        assert "batch=true" in uri_arg
-        assert "commit=true" in uri_arg
 
 
 class TestLambdaHandlerAuthenticationFailures:
@@ -259,24 +276,16 @@ class TestLambdaHandlerAuthenticationFailures:
         mock_service_provider,
         token_cache_stubber,
         valid_hawk_id,
+        hawk_key,
     ):
         """Test handling of invalid HAWK signature"""
-        token_cache_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
-                    "hawk_key": {"S": "a" * 64},
-                    "user_id": {"S": "user123"},
-                    "generation": {"N": "5"},
-                    "expiry": {"N": str(int(time.time()) + 300)},
-                    "created_at": {"N": str(int(time.time()))},
-                }
-            },
-            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
-        )
+        # Replace the valid header with one that has a wrong MAC
+        authorizer_event["headers"][
+            "Authorization"
+        ] = f'Hawk id="{valid_hawk_id}", ts="{int(time.time())}", nonce="abc123", mac="invalid_mac"'
 
-        # Don't mock verify_mac - let it fail naturally with invalid MAC
+        stub_token_cache(token_cache_stubber, valid_hawk_id, hawk_key)
+
         with pytest.raises(Exception) as exc_info:
             lambda_handler(authorizer_event, lambda_context, mock_service_provider)
 
@@ -303,22 +312,11 @@ class TestLambdaHandlerAuthenticationFailures:
         mock_service_provider,
         token_cache_stubber,
         valid_hawk_id,
+        hawk_key,
     ):
         """Test handling of invalid generation number"""
-        token_cache_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
-                    "hawk_key": {"S": "a" * 64},
-                    "user_id": {"S": "user123"},
-                    "generation": {"N": "10"},  # Different generation
-                    "expiry": {"N": str(int(time.time()) + 300)},
-                    "created_at": {"N": str(int(time.time()))},
-                }
-            },
-            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
-        )
+        # Stub with different generation (10 vs 5 in hawk_id)
+        stub_token_cache(token_cache_stubber, valid_hawk_id, hawk_key, generation=10)
 
         with pytest.raises(Exception) as exc_info:
             lambda_handler(authorizer_event, lambda_context, mock_service_provider)
@@ -414,63 +412,72 @@ class TestLambdaHandlerEdgeCases:
 
     def test_lambda_handler_missing_request_context(
         self,
-        authorizer_event,
         lambda_context,
         mock_service_provider,
         token_cache_stubber,
         valid_hawk_id,
+        hawk_key,
     ):
         """Test handling when requestContext is missing or has no domainName"""
-        authorizer_event["requestContext"] = {}
-
-        token_cache_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
-                    "hawk_key": {"S": "a" * 64},
-                    "user_id": {"S": "user123"},
-                    "generation": {"N": "5"},
-                    "expiry": {"N": str(int(time.time()) + 300)},
-                    "created_at": {"N": str(int(time.time()))},
-                }
-            },
-            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
+        # When domainName is empty, host defaults to "" and port to 443
+        auth_header = build_hawk_auth_header(
+            valid_hawk_id, hawk_key, "GET", "/1.5/12345/storage/bookmarks", "", 443
         )
+        event = {
+            "version": "1.0",
+            "type": "REQUEST",
+            "methodArn": "arn:aws:execute-api:us-east-1:123456789012:abcdef123/prod/GET/storage/bookmarks",
+            "identitySource": "",
+            "authorizationToken": "",
+            "resource": "/1.5/12345/storage/bookmarks",
+            "path": "/1.5/12345/storage/bookmarks",
+            "httpMethod": "GET",
+            "headers": {"Authorization": auth_header},
+            "queryStringParameters": {},
+            "pathParameters": {"uid": "12345"},
+            "stageVariables": {},
+            "requestContext": {},
+        }
 
-        mock_service_provider.hawk_service.verify_mac = MagicMock(return_value=True)
-        result = lambda_handler(authorizer_event, lambda_context, mock_service_provider)
+        stub_token_cache(token_cache_stubber, valid_hawk_id, hawk_key)
+        stub_nonce(token_cache_stubber)
+
+        result = lambda_handler(event, lambda_context, mock_service_provider)
 
         assert result["principalId"] == "user123"
 
     def test_lambda_handler_partial_request_context(
         self,
-        authorizer_event,
         lambda_context,
         mock_service_provider,
         token_cache_stubber,
         valid_hawk_id,
+        hawk_key,
     ):
         """Test handling when requestContext has partial data"""
-        authorizer_event["httpMethod"] = "POST"
-        authorizer_event["requestContext"] = {}
-
-        token_cache_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{valid_hawk_id}"},
-                    "hawk_key": {"S": "a" * 64},
-                    "user_id": {"S": "user123"},
-                    "generation": {"N": "5"},
-                    "expiry": {"N": str(int(time.time()) + 300)},
-                    "created_at": {"N": str(int(time.time()))},
-                }
-            },
-            {"Key": {"PK": f"TOKEN#{valid_hawk_id}"}, "TableName": "test-token-cache-table"},
+        # When domainName is empty, host defaults to "" and port to 443
+        auth_header = build_hawk_auth_header(
+            valid_hawk_id, hawk_key, "POST", "/1.5/12345/storage/bookmarks", "", 443
         )
+        event = {
+            "version": "1.0",
+            "type": "REQUEST",
+            "methodArn": "arn:aws:execute-api:us-east-1:123456789012:abcdef123/prod/POST/storage/bookmarks",
+            "identitySource": "",
+            "authorizationToken": "",
+            "resource": "/1.5/12345/storage/bookmarks",
+            "path": "/1.5/12345/storage/bookmarks",
+            "httpMethod": "POST",
+            "headers": {"Authorization": auth_header},
+            "queryStringParameters": {},
+            "pathParameters": {"uid": "12345"},
+            "stageVariables": {},
+            "requestContext": {},
+        }
 
-        mock_service_provider.hawk_service.verify_mac = MagicMock(return_value=True)
-        result = lambda_handler(authorizer_event, lambda_context, mock_service_provider)
+        stub_token_cache(token_cache_stubber, valid_hawk_id, hawk_key)
+        stub_nonce(token_cache_stubber)
+
+        result = lambda_handler(event, lambda_context, mock_service_provider)
 
         assert result["principalId"] == "user123"

--- a/lambda/tests/fixtures/integration.py
+++ b/lambda/tests/fixtures/integration.py
@@ -4,9 +4,37 @@ import json
 import time
 from typing import Any, Dict, List, Optional
 
+import mohawk
 import pytest
 
 from src.services.token_generator import TokenGenerator
+
+# ============================================================================
+# HAWK Header Builder
+# ============================================================================
+
+
+def build_hawk_auth_header(hawk_id, hawk_key, method, path, host, port, **kwargs):
+    """Build a Hawk Authorization header using mohawk.Sender.
+
+    Args:
+        hawk_id: Hawk credential ID
+        hawk_key: Hawk credential key (string, used as-is)
+        method: HTTP method (GET, POST, etc.)
+        path: Request path
+        host: Request host
+        port: Request port (string or int)
+        **kwargs: Additional arguments passed to mohawk.Sender
+    """
+    sender = mohawk.Sender(
+        credentials={"id": hawk_id, "key": hawk_key, "algorithm": "sha256"},
+        url=f"https://{host}:{port}{path}",
+        method=method,
+        always_hash_content=False,
+        **kwargs,
+    )
+    return sender.request_header
+
 
 # ============================================================================
 # HAWK Authentication Fixtures

--- a/lambda/tests/integration/test_e2e_flow.py
+++ b/lambda/tests/integration/test_e2e_flow.py
@@ -14,10 +14,15 @@ import json
 import time
 
 import pytest
+from botocore.stub import ANY
 
 from src.entrypoint.hawk_authorizer import lambda_handler as authorizer_handler
 from src.entrypoint.storage_api import lambda_handler as storage_handler
-from tests.fixtures.integration import build_authorizer_event, build_storage_event
+from tests.fixtures.integration import (
+    build_authorizer_event,
+    build_hawk_auth_header,
+    build_storage_event,
+)
 
 
 class TestHawkAuthorizerToStorageAPIFlow:
@@ -47,27 +52,15 @@ class TestHawkAuthorizerToStorageAPIFlow:
         dynamodb_stubber.add_response("put_item", {})
         hawk_service.store_token_in_cache(credentials)
 
-        # Build valid HAWK Authorization header
-        timestamp = int(time.time())
-        nonce = "test-nonce-123"
+        # Build valid HAWK Authorization header using mohawk.Sender
         method = "GET"
         path = "/1.5/12345/storage/bookmarks"
         host = "storage.sync.example.com"
         port = 443
 
-        # Calculate valid MAC
-        normalized = hawk_service.build_normalized_string(
-            str(timestamp), nonce, method, path, host, str(port)
-        )
-        # hawk_key is guaranteed to be present after generate_hawk_credentials
         assert credentials.hawk_key is not None
-        mac = hawk_service.calculate_mac(credentials.hawk_key, normalized)
-
-        authorization_header = (
-            f'Hawk id="{credentials.hawk_id}", '
-            f'ts="{timestamp}", '
-            f'nonce="{nonce}", '
-            f'mac="{mac}"'
+        authorization_header = build_hawk_auth_header(
+            credentials.hawk_id, credentials.hawk_key, method, path, host, port
         )
 
         # Step 1: Call HAWK authorizer
@@ -87,6 +80,17 @@ class TestHawkAuthorizerToStorageAPIFlow:
                     "expiry": {"N": str(expiry)},
                     "created_at": {"N": str(int(time.time()))},
                 }
+            },
+        )
+
+        # Nonce replay protection: put_item for nonce record
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": "test-token-cache-table",
+                "Item": ANY,
+                "ConditionExpression": "attribute_not_exists(PK)",
             },
         )
 
@@ -166,44 +170,21 @@ class TestHawkAuthorizerToStorageAPIFlow:
         hawk_id = hawk_service.generate_hawk_id(user_id, generation, expiry)
         hawk_key = hawk_service.generate_hawk_key()
 
-        # Store in cache (even though expired) - stub the put_item call
-        dynamodb_stubber.add_response("put_item", {})
-
-        # Build HAWK Authorization header with expired token
-        timestamp = int(time.time())
-        nonce = "test-nonce-123"
+        # Build HAWK Authorization header with expired token using mohawk.Sender
         method = "GET"
         path = "/1.5/12345/storage/bookmarks"
         host = "storage.sync.example.com"
         port = 443
 
-        normalized = hawk_service.build_normalized_string(
-            str(timestamp), nonce, method, path, host, str(port)
-        )
-        mac = hawk_service.calculate_mac(hawk_key, normalized)
-
-        authorization_header = (
-            f'Hawk id="{hawk_id}", ' f'ts="{timestamp}", ' f'nonce="{nonce}", ' f'mac="{mac}"'
-        )
+        authorization_header = build_hawk_auth_header(hawk_id, hawk_key, method, path, host, port)
 
         authorizer_event = build_authorizer_event(
             method=method, path=path, authorization_header=authorization_header
         )
 
-        # Mock get_item for HAWK token retrieval (expired token)
-        dynamodb_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{hawk_id}"},
-                    "hawk_key": {"S": hawk_key},
-                    "user_id": {"S": user_id},
-                    "generation": {"N": str(generation)},
-                    "expiry": {"N": str(expiry)},
-                    "created_at": {"N": str(int(time.time()) - 200)},
-                }
-            },
-        )
+        # The expiry check happens BEFORE mohawk Receiver is called
+        # (in _extract_hawk_id -> decode_hawk_id -> validate_hawk_id_expiry)
+        # so no DynamoDB stub is needed - it rejects early
 
         # Authorizer should reject expired token
         with pytest.raises(Exception, match="Unauthorized"):

--- a/lambda/tests/integration/test_token_to_storage_flow.py
+++ b/lambda/tests/integration/test_token_to_storage_flow.py
@@ -1,5 +1,5 @@
 """
-Integration test for Token Server → Storage Server flow.
+Integration test for Token Server -> Storage Server flow.
 
 Tests the complete end-to-end flow:
 1. Token Server receives OIDC token and generates HAWK credentials
@@ -20,7 +20,11 @@ from botocore.stub import ANY
 from src.entrypoint.hawk_authorizer import lambda_handler as authorizer_handler
 from src.entrypoint.storage_api import lambda_handler as storage_handler
 from src.entrypoint.token_api import lambda_handler as token_handler
-from tests.fixtures.integration import build_authorizer_event, build_storage_event
+from tests.fixtures.integration import (
+    build_authorizer_event,
+    build_hawk_auth_header,
+    build_storage_event,
+)
 
 
 class TestTokenServerToStorageServerFlow:
@@ -33,7 +37,7 @@ class TestTokenServerToStorageServerFlow:
         sample_lambda_context,
     ):
         """
-        Test complete flow: Token issuance → HAWK authentication → Storage access.
+        Test complete flow: Token issuance -> HAWK authentication -> Storage access.
 
         Flow:
         1. Client sends OIDC token to Token Server
@@ -147,24 +151,13 @@ class TestTokenServerToStorageServerFlow:
 
         # ===== Step 7-10: Storage Server Validates HAWK Credentials =====
 
-        # Build valid HAWK Authorization header
-        hawk_service = mock_service_provider.hawk_service
-        timestamp = int(time.time())
-        nonce = "test-nonce-integration"
+        # Build valid HAWK Authorization header using mohawk.Sender
         method = "GET"
         path = "/1.5/12345/storage/bookmarks"
         host = "storage.sync.example.com"
         port = 443
 
-        # Calculate valid MAC using the HAWK key from Token Server
-        normalized = hawk_service.build_normalized_string(
-            str(timestamp), nonce, method, path, host, str(port)
-        )
-        mac = hawk_service.calculate_mac(hawk_key, normalized)
-
-        authorization_header = (
-            f'Hawk id="{hawk_id}", ' f'ts="{timestamp}", ' f'nonce="{nonce}", ' f'mac="{mac}"'
-        )
+        authorization_header = build_hawk_auth_header(hawk_id, hawk_key, method, path, host, port)
 
         # Build HAWK authorizer event
         authorizer_event = build_authorizer_event(
@@ -193,6 +186,17 @@ class TestTokenServerToStorageServerFlow:
             expected_params={
                 "TableName": "test-token-cache-table",
                 "Key": {"PK": f"TOKEN#{hawk_id}"},  # Table resource format (no type descriptors)
+            },
+        )
+
+        # Nonce replay protection: put_item for nonce record
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            expected_params={
+                "TableName": "test-token-cache-table",
+                "Item": ANY,
+                "ConditionExpression": "attribute_not_exists(PK)",
             },
         )
 
@@ -410,45 +414,21 @@ class TestTokenServerToStorageServerFlow:
         hawk_id = hawk_service.generate_hawk_id(user_id, generation, expiry)
         hawk_key = hawk_service.generate_hawk_key()
 
-        # Build HAWK Authorization header with expired token
-        timestamp = int(time.time())
-        nonce = "test-nonce-expired"
+        # Build HAWK Authorization header with expired token using mohawk.Sender
         method = "GET"
         path = "/1.5/12345/storage/bookmarks"
         host = "storage.sync.example.com"
         port = 443
 
-        normalized = hawk_service.build_normalized_string(
-            str(timestamp), nonce, method, path, host, str(port)
-        )
-        mac = hawk_service.calculate_mac(hawk_key, normalized)
-
-        authorization_header = (
-            f'Hawk id="{hawk_id}", ' f'ts="{timestamp}", ' f'nonce="{nonce}", ' f'mac="{mac}"'
-        )
+        authorization_header = build_hawk_auth_header(hawk_id, hawk_key, method, path, host, port)
 
         authorizer_event = build_authorizer_event(
             method=method, path=path, authorization_header=authorization_header
         )
 
-        # Mock cache retrieval (token exists in cache but is expired)
-        dynamodb_stubber.add_response(
-            "get_item",
-            {
-                "Item": {
-                    "PK": {"S": f"TOKEN#{hawk_id}"},
-                    "hawk_key": {"S": hawk_key},
-                    "user_id": {"S": user_id},
-                    "generation": {"N": str(generation)},
-                    "expiry": {"N": str(expiry)},
-                    "created_at": {"N": str(int(time.time()) - 200)},
-                }
-            },
-            expected_params={
-                "TableName": "test-token-cache-table",
-                "Key": {"PK": f"TOKEN#{hawk_id}"},  # Table resource format (no type descriptors)
-            },
-        )
+        # The expiry check happens BEFORE mohawk Receiver is called
+        # (in _extract_hawk_id -> decode_hawk_id -> validate_hawk_id_expiry)
+        # so no DynamoDB stub is needed - it rejects early
 
         # Authorizer should reject expired token
         with pytest.raises(Exception, match="Unauthorized"):
@@ -545,19 +525,12 @@ class TestTokenServerToStorageServerFlow:
         hawk_id = hawk_service.generate_hawk_id(user_id, generation, expiry)
         hawk_key = hawk_service.generate_hawk_key()
 
-        # Build valid HAWK Authorization header
-        timestamp = int(time.time())
-        nonce = "test-nonce-gen"
+        # Build valid HAWK Authorization header using mohawk.Sender
         method = "GET"
         path = "/1.5/12345/storage/bookmarks"
 
-        normalized = hawk_service.build_normalized_string(
-            str(timestamp), nonce, method, path, "storage.sync.example.com", "443"
-        )
-        mac = hawk_service.calculate_mac(hawk_key, normalized)
-
-        authorization_header = (
-            f'Hawk id="{hawk_id}", ' f'ts="{timestamp}", ' f'nonce="{nonce}", ' f'mac="{mac}"'
+        authorization_header = build_hawk_auth_header(
+            hawk_id, hawk_key, method, path, "storage.sync.example.com", 443
         )
 
         authorizer_event = build_authorizer_event(

--- a/lambda/tests/services/test_fxa_token_manager.py
+++ b/lambda/tests/services/test_fxa_token_manager.py
@@ -1,11 +1,9 @@
 """Unit tests for FxATokenManager with DynamoDB stubber"""
 
-import base64
-import hashlib
-import hmac
 from unittest.mock import patch
 
 import pytest
+from botocore.stub import ANY
 
 from src.services import fxa_crypto
 from src.services.fxa_token_manager import (
@@ -13,6 +11,7 @@ from src.services.fxa_token_manager import (
     SESSION_TOKEN_INFO,
     FxATokenManager,
 )
+from tests.fixtures.integration import build_hawk_auth_header as build_hawk_header
 
 
 class TestCreateSessionToken:
@@ -501,30 +500,6 @@ class TestVerifySessionHawk:
             mock.time.return_value = 1000000.0
             yield mock
 
-    def _build_hawk_header(
-        self,
-        token_id_hex,
-        req_hmac_key_hex,
-        method,
-        path,
-        host,
-        port,
-        ts="1000000",
-        nonce="abc123",
-        payload_hash=None,
-    ):
-        """Build a valid Hawk header with correct HMAC."""
-        hash_value = payload_hash or ""
-        canonical = (
-            f"hawk.1.header\n{ts}\n{nonce}\n{method}\n{path}\n{host}\n{port}\n{hash_value}\n\n"
-        )
-        req_hmac_key = bytes.fromhex(req_hmac_key_hex)
-        mac = hmac.new(req_hmac_key, canonical.encode("ascii"), hashlib.sha256).digest()
-        mac_b64 = base64.b64encode(mac).decode("ascii")
-        if payload_hash:
-            return f'Hawk id="{token_id_hex}", ts="{ts}", nonce="{nonce}", hash="{payload_hash}", mac="{mac_b64}"'
-        return f'Hawk id="{token_id_hex}", ts="{ts}", nonce="{nonce}", mac="{mac_b64}"'
-
     def test_returns_uid_for_valid_hawk(
         self,
         manager,
@@ -537,7 +512,7 @@ class TestVerifySessionHawk:
         token_id_hex = "aa" * 32
         req_hmac_key_hex = "bb" * 32
 
-        auth_header = self._build_hawk_header(
+        auth_header = build_hawk_header(
             token_id_hex, req_hmac_key_hex, "GET", "/v1/session/status", "localhost", "443"
         )
 
@@ -555,6 +530,17 @@ class TestVerifySessionHawk:
             {
                 "TableName": storage_table_name,
                 "Key": {"PK": f"SESSION#{token_id_hex}"},
+            },
+        )
+
+        # Nonce replay protection: put_item for nonce record
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": ANY,
+                "ConditionExpression": "attribute_not_exists(PK)",
             },
         )
 
@@ -619,7 +605,7 @@ class TestVerifySessionHawk:
         token_id_hex = "aa" * 32
         req_hmac_key_hex = "bb" * 32
 
-        auth_header = self._build_hawk_header(
+        auth_header = build_hawk_header(
             token_id_hex, req_hmac_key_hex, "GET", "/v1/session/status", "localhost", "443"
         )
 
@@ -699,7 +685,7 @@ class TestVerifySessionHawk:
         result = manager.verify_session_hawk(auth_header, "GET", "/path", "host", "443")
         assert result is None
 
-    def test_returns_uid_with_payload_hash(
+    def test_returns_uid_for_post_request(
         self,
         manager,
         dynamodb_stubber,
@@ -707,21 +693,14 @@ class TestVerifySessionHawk:
         sample_uid,
         mock_time,
     ):
-        """verify_session_hawk returns uid when Hawk header includes a payload hash"""
+        """verify_session_hawk returns uid for POST requests (no content hash needed)"""
         token_id_hex = "aa" * 32
         req_hmac_key_hex = "bb" * 32
-        payload_hash = base64.b64encode(
-            hashlib.sha256(b'{"grant_type":"fxa-credentials"}').digest()
-        ).decode("ascii")
 
-        auth_header = self._build_hawk_header(
-            token_id_hex,
-            req_hmac_key_hex,
-            "POST",
-            "/v1/oauth/token",
-            "localhost",
-            "443",
-            payload_hash=payload_hash,
+        # Build header without content hash (clients don't send hash when server
+        # uses accept_untrusted_content=True)
+        auth_header = build_hawk_header(
+            token_id_hex, req_hmac_key_hex, "POST", "/v1/oauth/token", "localhost", "443"
         )
 
         dynamodb_stubber.add_response(
@@ -738,6 +717,17 @@ class TestVerifySessionHawk:
             {
                 "TableName": storage_table_name,
                 "Key": {"PK": f"SESSION#{token_id_hex}"},
+            },
+        )
+
+        # Nonce replay protection: put_item for nonce record
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": ANY,
+                "ConditionExpression": "attribute_not_exists(PK)",
             },
         )
 
@@ -747,7 +737,7 @@ class TestVerifySessionHawk:
 
         assert result == sample_uid
 
-    def test_returns_none_for_wrong_payload_hash(
+    def test_returns_none_for_malformed_hawk_header(
         self,
         manager,
         dynamodb_stubber,
@@ -755,27 +745,33 @@ class TestVerifySessionHawk:
         sample_uid,
         mock_time,
     ):
-        """verify_session_hawk returns None when payload hash in header doesn't match MAC"""
+        """verify_session_hawk returns None for completely malformed header"""
+        # Not a valid Hawk header at all
+        auth_header = "Bearer some-token"
+
+        result = manager.verify_session_hawk(
+            auth_header, "GET", "/v1/session/status", "localhost", "443"
+        )
+
+        assert result is None
+
+    def test_returns_none_for_replayed_nonce(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        mock_time,
+    ):
+        """verify_session_hawk returns None when nonce has been replayed"""
         token_id_hex = "aa" * 32
         req_hmac_key_hex = "bb" * 32
 
-        # Build header with one hash but compute MAC with a different hash
-        real_hash = base64.b64encode(hashlib.sha256(b"real payload").digest()).decode("ascii")
-        wrong_hash = base64.b64encode(hashlib.sha256(b"wrong payload").digest()).decode("ascii")
-
-        # Build a valid header with real_hash, then swap the hash field to wrong_hash
-        auth_header = self._build_hawk_header(
-            token_id_hex,
-            req_hmac_key_hex,
-            "POST",
-            "/v1/oauth/token",
-            "localhost",
-            "443",
-            payload_hash=real_hash,
+        auth_header = build_hawk_header(
+            token_id_hex, req_hmac_key_hex, "GET", "/v1/session/status", "localhost", "443"
         )
-        # Replace the hash value in the header with the wrong one
-        auth_header = auth_header.replace(real_hash, wrong_hash, 1)
 
+        # Stub: credential lookup succeeds
         dynamodb_stubber.add_response(
             "get_item",
             {
@@ -793,11 +789,66 @@ class TestVerifySessionHawk:
             },
         )
 
-        result = manager.verify_session_hawk(
-            auth_header, "POST", "/v1/oauth/token", "localhost", "443"
+        # Stub: nonce already seen
+        dynamodb_stubber.add_client_error(
+            "put_item",
+            service_error_code="ConditionalCheckFailedException",
+            service_message="The conditional request failed",
         )
 
+        result = manager.verify_session_hawk(
+            auth_header, "GET", "/v1/session/status", "localhost", "443"
+        )
         assert result is None
+
+    def test_reraises_non_conditional_nonce_error(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        mock_time,
+    ):
+        """verify_session_hawk re-raises non-ConditionalCheckFailed errors from nonce check"""
+        from botocore.exceptions import ClientError
+
+        token_id_hex = "aa" * 32
+        req_hmac_key_hex = "bb" * 32
+
+        auth_header = build_hawk_header(
+            token_id_hex, req_hmac_key_hex, "GET", "/v1/session/status", "localhost", "443"
+        )
+
+        # Stub: credential lookup succeeds
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"SESSION#{token_id_hex}"},
+                    "uid": {"S": sample_uid},
+                    "verified": {"BOOL": True},
+                    "expiry": {"N": "1002592000"},
+                    "reqHMACkey": {"S": req_hmac_key_hex},
+                }
+            },
+            {
+                "TableName": storage_table_name,
+                "Key": {"PK": f"SESSION#{token_id_hex}"},
+            },
+        )
+
+        # Stub: nonce check fails with non-conditional error
+        dynamodb_stubber.add_client_error(
+            "put_item",
+            service_error_code="InternalServerError",
+            service_message="Internal server error",
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            manager.verify_session_hawk(
+                auth_header, "GET", "/v1/session/status", "localhost", "443"
+            )
+        assert exc_info.value.response["Error"]["Code"] == "InternalServerError"
 
 
 class TestVerifyKeyfetchHawk:
@@ -817,30 +868,6 @@ class TestVerifyKeyfetchHawk:
             mock.time.return_value = 1000000.0
             yield mock
 
-    def _build_hawk_header(
-        self,
-        token_id_hex,
-        req_hmac_key_hex,
-        method,
-        path,
-        host,
-        port,
-        ts="1000000",
-        nonce="abc123",
-        payload_hash=None,
-    ):
-        """Build a valid Hawk header with correct HMAC."""
-        hash_value = payload_hash or ""
-        canonical = (
-            f"hawk.1.header\n{ts}\n{nonce}\n{method}\n{path}\n{host}\n{port}\n{hash_value}\n\n"
-        )
-        req_hmac_key = bytes.fromhex(req_hmac_key_hex)
-        mac = hmac.new(req_hmac_key, canonical.encode("ascii"), hashlib.sha256).digest()
-        mac_b64 = base64.b64encode(mac).decode("ascii")
-        if payload_hash:
-            return f'Hawk id="{token_id_hex}", ts="{ts}", nonce="{nonce}", hash="{payload_hash}", mac="{mac_b64}"'
-        return f'Hawk id="{token_id_hex}", ts="{ts}", nonce="{nonce}", mac="{mac_b64}"'
-
     def test_returns_token_data_for_valid_hawk(
         self,
         manager,
@@ -854,7 +881,7 @@ class TestVerifyKeyfetchHawk:
         req_hmac_key_hex = "bb" * 32
         raw_token_hex = "cc" * 32
 
-        auth_header = self._build_hawk_header(
+        auth_header = build_hawk_header(
             token_id_hex, req_hmac_key_hex, "GET", "/v1/account/keys", "localhost", "443"
         )
 
@@ -874,6 +901,17 @@ class TestVerifyKeyfetchHawk:
                 "Key": {"PK": f"KEYFETCH#{token_id_hex}"},
                 "ReturnValues": "ALL_OLD",
                 "ConditionExpression": "attribute_exists(PK)",
+            },
+        )
+
+        # Nonce replay protection: put_item for nonce record
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": ANY,
+                "ConditionExpression": "attribute_not_exists(PK)",
             },
         )
 
@@ -924,7 +962,7 @@ class TestVerifyKeyfetchHawk:
         token_id_hex = "aa" * 32
         req_hmac_key_hex = "bb" * 32
 
-        auth_header = self._build_hawk_header(
+        auth_header = build_hawk_header(
             token_id_hex, req_hmac_key_hex, "GET", "/v1/account/keys", "localhost", "443"
         )
 
@@ -1074,7 +1112,7 @@ class TestVerifyKeyfetchHawk:
         )
         assert result is None
 
-    def test_returns_token_data_with_payload_hash(
+    def test_returns_token_data_for_post_request(
         self,
         manager,
         dynamodb_stubber,
@@ -1082,20 +1120,14 @@ class TestVerifyKeyfetchHawk:
         sample_uid,
         mock_time,
     ):
-        """verify_keyfetch_hawk returns uid and keyFetchToken when Hawk header includes a payload hash"""
+        """verify_keyfetch_hawk returns uid and keyFetchToken for POST requests"""
         token_id_hex = "aa" * 32
         req_hmac_key_hex = "bb" * 32
         raw_token_hex = "cc" * 32
-        payload_hash = base64.b64encode(hashlib.sha256(b"some payload").digest()).decode("ascii")
 
-        auth_header = self._build_hawk_header(
-            token_id_hex,
-            req_hmac_key_hex,
-            "POST",
-            "/v1/account/keys",
-            "localhost",
-            "443",
-            payload_hash=payload_hash,
+        # Build header without content hash
+        auth_header = build_hawk_header(
+            token_id_hex, req_hmac_key_hex, "POST", "/v1/account/keys", "localhost", "443"
         )
 
         dynamodb_stubber.add_response(
@@ -1117,6 +1149,17 @@ class TestVerifyKeyfetchHawk:
             },
         )
 
+        # Nonce replay protection: put_item for nonce record
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": ANY,
+                "ConditionExpression": "attribute_not_exists(PK)",
+            },
+        )
+
         result = manager.verify_keyfetch_hawk(
             auth_header, "POST", "/v1/account/keys", "localhost", "443"
         )
@@ -1124,6 +1167,77 @@ class TestVerifyKeyfetchHawk:
         assert result is not None
         assert result["uid"] == sample_uid
         assert result["keyFetchToken"] == raw_token_hex
+
+    def test_returns_none_for_replayed_nonce(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        mock_time,
+    ):
+        """verify_keyfetch_hawk returns None when nonce has been replayed"""
+        token_id_hex = "aa" * 32
+        req_hmac_key_hex = "bb" * 32
+        raw_token_hex = "cc" * 32
+
+        auth_header = build_hawk_header(
+            token_id_hex, req_hmac_key_hex, "GET", "/v1/account/keys", "localhost", "443"
+        )
+
+        # Stub: credential lookup succeeds (atomic delete)
+        dynamodb_stubber.add_response(
+            "delete_item",
+            {
+                "Attributes": {
+                    "PK": {"S": f"KEYFETCH#{token_id_hex}"},
+                    "uid": {"S": sample_uid},
+                    "keyFetchToken": {"S": raw_token_hex},
+                    "reqHMACkey": {"S": req_hmac_key_hex},
+                    "expiry": {"N": "1000300"},
+                }
+            },
+            {
+                "TableName": storage_table_name,
+                "Key": {"PK": f"KEYFETCH#{token_id_hex}"},
+                "ReturnValues": "ALL_OLD",
+                "ConditionExpression": "attribute_exists(PK)",
+            },
+        )
+
+        # Stub: nonce already seen
+        dynamodb_stubber.add_client_error(
+            "put_item",
+            service_error_code="ConditionalCheckFailedException",
+            service_message="The conditional request failed",
+        )
+
+        result = manager.verify_keyfetch_hawk(
+            auth_header, "GET", "/v1/account/keys", "localhost", "443"
+        )
+        assert result is None
+
+
+class TestVerifyKeyfetchHawkEdgeCases:
+    """Edge case tests for verify_keyfetch_hawk"""
+
+    @pytest.fixture
+    def manager(self, dynamodb_table):
+        return FxATokenManager(table=dynamodb_table)
+
+    def test_returns_none_when_receiver_skips_credentials_map(self, manager):
+        """verify_keyfetch_hawk returns None when result_holder has no uid
+        (edge case: mohawk.Receiver completes but credentials_map was not invoked)"""
+        token_id_hex = "aa" * 32
+        auth_header = f'Hawk id="{token_id_hex}", ts="1000000", nonce="abc", mac="AAAA"'
+
+        with patch("src.services.fxa_token_manager.mohawk.Receiver"):
+            # Mock Receiver to succeed without calling credentials_map,
+            # so result_holder stays empty
+            result = manager.verify_keyfetch_hawk(
+                auth_header, "GET", "/v1/account/keys", "localhost", "443"
+            )
+        assert result is None
 
 
 class TestDeleteSession:

--- a/lambda/tests/services/test_hawk_service.py
+++ b/lambda/tests/services/test_hawk_service.py
@@ -2,9 +2,12 @@
 
 import base64
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import mohawk
+import mohawk.exc
 import pytest
+from botocore.exceptions import ClientError
 
 from src.services.hawk_service import HawkCredentials, HawkService
 from src.shared.exceptions import (
@@ -14,6 +17,7 @@ from src.shared.exceptions import (
     InvalidHawkHeaderException,
     InvalidHawkSignatureException,
 )
+from tests.fixtures.integration import build_hawk_auth_header
 
 
 @pytest.fixture
@@ -38,72 +42,34 @@ class TestHawkServiceInit:
         assert hawk_service.token_cache_table is mock_dynamodb_table
 
 
-class TestParseHawkHeader:
-    """Tests for parse_hawk_header method"""
+class TestExtractHawkId:
+    """Tests for _extract_hawk_id method"""
 
-    def test_parse_valid_hawk_header(self, hawk_service):
-        """Test parsing a valid HAWK header"""
-        header = 'Hawk id="abc123", ts="1234567890", nonce="xyz", mac="signature=="'
-        result = hawk_service.parse_hawk_header(header)
+    def test_extract_hawk_id_valid(self, hawk_service):
+        """Test extracting id from a valid Hawk header"""
+        header = 'Hawk id="abc123", ts="1234567890", nonce="xyz", mac="sig=="'
+        result = hawk_service._extract_hawk_id(header)
+        assert result == "abc123"
 
-        assert result["id"] == "abc123"
-        assert result["ts"] == "1234567890"
-        assert result["nonce"] == "xyz"
-        assert result["mac"] == "signature=="
+    def test_extract_hawk_id_missing_prefix(self, hawk_service):
+        """Test extraction fails when header doesn't start with 'Hawk '"""
+        with pytest.raises(InvalidHawkHeaderException, match="must start with 'Hawk '"):
+            hawk_service._extract_hawk_id('id="abc123", ts="1234567890"')
 
-    def test_parse_hawk_header_missing_prefix(self, hawk_service):
-        """Test parsing header without 'Hawk ' prefix"""
-        header = 'id="abc123", ts="1234567890", nonce="xyz", mac="signature=="'
+    def test_extract_hawk_id_empty_header(self, hawk_service):
+        """Test extraction fails for empty header"""
+        with pytest.raises(InvalidHawkHeaderException, match="must start with 'Hawk '"):
+            hawk_service._extract_hawk_id("")
 
-        with pytest.raises(InvalidHawkHeaderException) as exc_info:
-            hawk_service.parse_hawk_header(header)
+    def test_extract_hawk_id_none_header(self, hawk_service):
+        """Test extraction fails for None header"""
+        with pytest.raises(InvalidHawkHeaderException, match="must start with 'Hawk '"):
+            hawk_service._extract_hawk_id(None)
 
-        assert "must start with 'Hawk '" in str(exc_info.value)
-
-    def test_parse_hawk_header_missing_id(self, hawk_service):
-        """Test parsing header missing required 'id' field"""
-        header = 'Hawk ts="1234567890", nonce="xyz", mac="signature=="'
-
-        with pytest.raises(InvalidHawkHeaderException) as exc_info:
-            hawk_service.parse_hawk_header(header)
-
-        assert "Missing required HAWK parameter: id" in str(exc_info.value)
-
-    def test_parse_hawk_header_missing_ts(self, hawk_service):
-        """Test parsing header missing required 'ts' field"""
-        header = 'Hawk id="abc123", nonce="xyz", mac="signature=="'
-
-        with pytest.raises(InvalidHawkHeaderException) as exc_info:
-            hawk_service.parse_hawk_header(header)
-
-        assert "Missing required HAWK parameter: ts" in str(exc_info.value)
-
-    def test_parse_hawk_header_missing_nonce(self, hawk_service):
-        """Test parsing header missing required 'nonce' field"""
-        header = 'Hawk id="abc123", ts="1234567890", mac="signature=="'
-
-        with pytest.raises(InvalidHawkHeaderException) as exc_info:
-            hawk_service.parse_hawk_header(header)
-
-        assert "Missing required HAWK parameter: nonce" in str(exc_info.value)
-
-    def test_parse_hawk_header_missing_mac(self, hawk_service):
-        """Test parsing header missing required 'mac' field"""
-        header = 'Hawk id="abc123", ts="1234567890", nonce="xyz"'
-
-        with pytest.raises(InvalidHawkHeaderException) as exc_info:
-            hawk_service.parse_hawk_header(header)
-
-        assert "Missing required HAWK parameter: mac" in str(exc_info.value)
-
-    def test_parse_hawk_header_invalid_format(self, hawk_service):
-        """Test parsing header with invalid parameter format"""
-        header = 'Hawk id="abc123", invalid_param, ts="1234567890"'
-
-        with pytest.raises(InvalidHawkHeaderException) as exc_info:
-            hawk_service.parse_hawk_header(header)
-
-        assert "Invalid HAWK parameter" in str(exc_info.value)
+    def test_extract_hawk_id_missing_id_field(self, hawk_service):
+        """Test extraction fails when id field is missing"""
+        with pytest.raises(InvalidHawkHeaderException, match="Missing id"):
+            hawk_service._extract_hawk_id('Hawk ts="1234567890", nonce="xyz"')
 
 
 class TestDecodeHawkId:
@@ -189,237 +155,6 @@ class TestValidateHawkIdExpiry:
         assert result is False
 
 
-class TestValidateTimestamp:
-    """Tests for validate_timestamp method"""
-
-    def test_validate_timestamp_within_skew(self, hawk_service):
-        """Test validation of timestamp within acceptable skew"""
-        current_time = int(time.time())
-
-        result = hawk_service.validate_timestamp(current_time)
-
-        assert result is True
-
-    def test_validate_timestamp_past_within_skew(self, hawk_service):
-        """Test validation of past timestamp within skew"""
-        past_time = int(time.time()) - 30  # 30 seconds ago
-
-        result = hawk_service.validate_timestamp(past_time)
-
-        assert result is True
-
-    def test_validate_timestamp_future_within_skew(self, hawk_service):
-        """Test validation of future timestamp within skew"""
-        future_time = int(time.time()) + 30  # 30 seconds in future
-
-        result = hawk_service.validate_timestamp(future_time)
-
-        assert result is True
-
-    def test_validate_timestamp_past_exceeds_skew(self, hawk_service):
-        """Test validation of past timestamp exceeding skew"""
-        past_time = int(time.time()) - 120  # 2 minutes ago (exceeds 60s skew)
-
-        result = hawk_service.validate_timestamp(past_time)
-
-        assert result is False
-
-    def test_validate_timestamp_future_exceeds_skew(self, hawk_service):
-        """Test validation of future timestamp exceeding skew"""
-        future_time = int(time.time()) + 120  # 2 minutes in future
-
-        result = hawk_service.validate_timestamp(future_time)
-
-        assert result is False
-
-
-class TestBuildNormalizedString:
-    """Tests for build_normalized_string method"""
-
-    def test_build_normalized_string_basic(self, hawk_service):
-        """Test building normalized string with basic parameters"""
-        result = hawk_service.build_normalized_string(
-            timestamp="1234567890",
-            nonce="abc123",
-            method="GET",
-            uri="/storage/bookmarks",
-            host="api.example.com",
-            port="443",
-        )
-
-        expected = (
-            "hawk.1.header\n"
-            "1234567890\n"
-            "abc123\n"
-            "GET\n"
-            "/storage/bookmarks\n"
-            "api.example.com\n"
-            "443\n"
-            "\n"
-            "\n"
-        )
-
-        assert result == expected
-
-    def test_build_normalized_string_with_payload_hash(self, hawk_service):
-        """Test building normalized string with payload hash"""
-        result = hawk_service.build_normalized_string(
-            timestamp="1234567890",
-            nonce="abc123",
-            method="POST",
-            uri="/storage/bookmarks",
-            host="api.example.com",
-            port="443",
-            payload_hash="hash123",
-        )
-
-        assert "hash123\n" in result
-
-    def test_build_normalized_string_with_ext(self, hawk_service):
-        """Test building normalized string with extension data"""
-        result = hawk_service.build_normalized_string(
-            timestamp="1234567890",
-            nonce="abc123",
-            method="GET",
-            uri="/storage/bookmarks",
-            host="api.example.com",
-            port="443",
-            ext="ext-data",
-        )
-
-        assert result.endswith("ext-data\n")
-
-    def test_build_normalized_string_uppercase_method(self, hawk_service):
-        """Test that method is converted to uppercase"""
-        result = hawk_service.build_normalized_string(
-            timestamp="1234567890",
-            nonce="abc123",
-            method="get",
-            uri="/storage/bookmarks",
-            host="api.example.com",
-            port="443",
-        )
-
-        assert "\nGET\n" in result
-
-    def test_build_normalized_string_lowercase_host(self, hawk_service):
-        """Test that host is converted to lowercase"""
-        result = hawk_service.build_normalized_string(
-            timestamp="1234567890",
-            nonce="abc123",
-            method="GET",
-            uri="/storage/bookmarks",
-            host="API.EXAMPLE.COM",
-            port="443",
-        )
-
-        assert "\napi.example.com\n" in result
-
-
-class TestCalculateMac:
-    """Tests for calculate_mac method"""
-
-    def test_calculate_mac_returns_base64(self, hawk_service):
-        """Test that MAC calculation returns base64-encoded string"""
-        key = "a" * 64  # 64-char hex string
-        normalized = "test string"
-
-        result = hawk_service.calculate_mac(key, normalized)
-
-        # Should be base64-encoded
-        assert isinstance(result, str)
-        # Base64 strings only contain these characters
-        assert all(
-            c in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" for c in result
-        )
-
-    def test_calculate_mac_deterministic(self, hawk_service):
-        """Test that MAC calculation is deterministic"""
-        key = "a" * 64
-        normalized = "test string"
-
-        result1 = hawk_service.calculate_mac(key, normalized)
-        result2 = hawk_service.calculate_mac(key, normalized)
-
-        assert result1 == result2
-
-    def test_calculate_mac_different_keys(self, hawk_service):
-        """Test that different keys produce different MACs"""
-        key1 = "a" * 64
-        key2 = "b" * 64
-        normalized = "test string"
-
-        result1 = hawk_service.calculate_mac(key1, normalized)
-        result2 = hawk_service.calculate_mac(key2, normalized)
-
-        assert result1 != result2
-
-
-class TestVerifyMac:
-    """Tests for verify_mac method"""
-
-    def test_verify_mac_valid(self, hawk_service):
-        """Test verification of valid MAC"""
-        key = "a" * 64
-        timestamp = 1234567890
-        nonce = "abc123"
-        method = "GET"
-        uri = "/storage/bookmarks"
-        host = "api.example.com"
-        port = 443
-
-        # Calculate expected MAC
-        normalized = hawk_service.build_normalized_string(
-            str(timestamp), nonce, method, uri, host, str(port)
-        )
-        expected_mac = hawk_service.calculate_mac(key, normalized)
-
-        result = hawk_service.verify_mac(
-            key, expected_mac, timestamp, nonce, method, uri, host, port
-        )
-
-        assert result is True
-
-    def test_verify_mac_invalid(self, hawk_service):
-        """Test verification of invalid MAC"""
-        key = "a" * 64
-        invalid_mac = "invalid_signature"
-        timestamp = 1234567890
-        nonce = "abc123"
-        method = "GET"
-        uri = "/storage/bookmarks"
-        host = "api.example.com"
-        port = 443
-
-        result = hawk_service.verify_mac(
-            key, invalid_mac, timestamp, nonce, method, uri, host, port
-        )
-
-        assert result is False
-
-    def test_verify_mac_wrong_key(self, hawk_service):
-        """Test verification with wrong key"""
-        correct_key = "a" * 64
-        wrong_key = "b" * 64
-        timestamp = 1234567890
-        nonce = "abc123"
-        method = "GET"
-        uri = "/storage/bookmarks"
-        host = "api.example.com"
-        port = 443
-
-        # Calculate MAC with correct key
-        normalized = hawk_service.build_normalized_string(
-            str(timestamp), nonce, method, uri, host, str(port)
-        )
-        mac = hawk_service.calculate_mac(correct_key, normalized)
-
-        # Verify with wrong key
-        result = hawk_service.verify_mac(wrong_key, mac, timestamp, nonce, method, uri, host, port)
-
-        assert result is False
-
-
 class TestGetHawkKeyFromCache:
     """Tests for get_hawk_key_from_cache method"""
 
@@ -453,8 +188,6 @@ class TestGetHawkKeyFromCache:
 
     def test_get_hawk_key_dynamodb_error(self, hawk_service, mock_dynamodb_table):
         """Test retrieval when DynamoDB error occurs"""
-        from botocore.exceptions import ClientError
-
         hawk_id = "test_hawk_id"
         mock_dynamodb_table.get_item.side_effect = ClientError(
             {"Error": {"Code": "ServiceUnavailable", "Message": "Service unavailable"}},
@@ -482,23 +215,13 @@ class TestValidate:
             .rstrip("=")
         )
         hawk_key = "a" * 64
-        timestamp = int(time.time())
-        nonce = "abc123"
         method = "GET"
         path = "/storage/bookmarks"
         host = "api.example.com"
         port = 443
 
-        # Calculate valid MAC
-        normalized = hawk_service.build_normalized_string(
-            str(timestamp), nonce, method, path, host, str(port)
-        )
-        mac = hawk_service.calculate_mac(hawk_key, normalized)
-
-        # Create HAWK header
-        authorization_header = (
-            f'Hawk id="{hawk_id}", ts="{timestamp}", nonce="{nonce}", mac="{mac}"'
-        )
+        # Build header using mohawk.Sender
+        authorization_header = build_hawk_auth_header(hawk_id, hawk_key, method, path, host, port)
 
         # Mock DynamoDB response
         mock_dynamodb_table.get_item.return_value = {
@@ -540,31 +263,6 @@ class TestValidate:
                 authorization_header, "GET", "/storage/bookmarks", "api.example.com", 443
             )
 
-    def test_validate_invalid_timestamp(self, hawk_service):
-        """Test validation with invalid timestamp"""
-        user_id = "user123"
-        generation = 5
-        expiry = int(time.time()) + 300
-        hawk_id = (
-            base64.urlsafe_b64encode(f"{user_id}:{generation}:{expiry}".encode())
-            .decode()
-            .rstrip("=")
-        )
-        timestamp = int(time.time()) - 200  # Too far in past
-        nonce = "abc123"
-        mac = "dummy_mac"
-
-        authorization_header = (
-            f'Hawk id="{hawk_id}", ts="{timestamp}", nonce="{nonce}", mac="{mac}"'
-        )
-
-        with pytest.raises(InvalidHawkSignatureException) as exc_info:
-            hawk_service.validate(
-                authorization_header, "GET", "/storage/bookmarks", "api.example.com", 443
-            )
-
-        assert "outside acceptable window" in str(exc_info.value)
-
     def test_validate_generation_mismatch(self, hawk_service, mock_dynamodb_table):
         """Test validation with generation mismatch"""
         user_id = "user123"
@@ -576,30 +274,29 @@ class TestValidate:
             .decode()
             .rstrip("=")
         )
-        timestamp = int(time.time())
-        nonce = "abc123"
-        mac = "dummy_mac"
+        hawk_key = "a" * 64
+        method = "GET"
+        path = "/storage/bookmarks"
+        host = "api.example.com"
+        port = 443
 
-        authorization_header = (
-            f'Hawk id="{hawk_id}", ts="{timestamp}", nonce="{nonce}", mac="{mac}"'
-        )
+        # Build a valid header (MAC will be valid, but generation will mismatch)
+        authorization_header = build_hawk_auth_header(hawk_id, hawk_key, method, path, host, port)
 
         # Mock DynamoDB response with different generation
         mock_dynamodb_table.get_item.return_value = {
             "Item": {
-                "hawk_key": "a" * 64,
+                "hawk_key": hawk_key,
                 "user_id": user_id,
                 "generation": cached_generation,
             }
         }
 
         with pytest.raises(InvalidGenerationException):
-            hawk_service.validate(
-                authorization_header, "GET", "/storage/bookmarks", "api.example.com", 443
-            )
+            hawk_service.validate(authorization_header, method, path, host, port)
 
-    def test_validate_invalid_signature(self, hawk_service, mock_dynamodb_table):
-        """Test validation with invalid signature"""
+    def test_validate_invalid_mac(self, hawk_service, mock_dynamodb_table):
+        """Test validation with invalid MAC (wrong key)"""
         user_id = "user123"
         generation = 5
         expiry = int(time.time()) + 300
@@ -608,15 +305,140 @@ class TestValidate:
             .decode()
             .rstrip("=")
         )
-        timestamp = int(time.time())
-        nonce = "abc123"
-        invalid_mac = "invalid_signature"
+        wrong_key = "b" * 64
+        correct_key = "a" * 64
+        method = "GET"
+        path = "/storage/bookmarks"
+        host = "api.example.com"
+        port = 443
 
-        authorization_header = (
-            f'Hawk id="{hawk_id}", ts="{timestamp}", nonce="{nonce}", mac="{invalid_mac}"'
+        # Build header with the wrong key
+        authorization_header = build_hawk_auth_header(hawk_id, wrong_key, method, path, host, port)
+
+        # Mock DynamoDB response with the correct key (different from what was used to sign)
+        mock_dynamodb_table.get_item.return_value = {
+            "Item": {
+                "hawk_key": correct_key,
+                "user_id": user_id,
+                "generation": generation,
+            }
+        }
+
+        with pytest.raises(InvalidHawkSignatureException, match="MAC verification failed"):
+            hawk_service.validate(authorization_header, method, path, host, port)
+
+    def test_validate_timestamp_outside_skew(self, hawk_service, mock_dynamodb_table):
+        """Test validation with timestamp outside acceptable window"""
+        user_id = "user123"
+        generation = 5
+        expiry = int(time.time()) + 300
+        hawk_id = (
+            base64.urlsafe_b64encode(f"{user_id}:{generation}:{expiry}".encode())
+            .decode()
+            .rstrip("=")
+        )
+        hawk_key = "a" * 64
+        method = "GET"
+        path = "/storage/bookmarks"
+        host = "api.example.com"
+        port = 443
+
+        # Build header with an old timestamp (200 seconds in the past, exceeding 60s skew)
+        old_ts = int(time.time()) - 200
+        authorization_header = build_hawk_auth_header(
+            hawk_id, hawk_key, method, path, host, port, _timestamp=old_ts
         )
 
         # Mock DynamoDB response
+        mock_dynamodb_table.get_item.return_value = {
+            "Item": {
+                "hawk_key": hawk_key,
+                "user_id": user_id,
+                "generation": generation,
+            }
+        }
+
+        with pytest.raises(InvalidHawkSignatureException, match="outside acceptable window"):
+            hawk_service.validate(authorization_header, method, path, host, port)
+
+    def test_validate_token_not_in_cache(self, hawk_service, mock_dynamodb_table):
+        """Test validation when token is not found in DynamoDB cache"""
+        user_id = "user123"
+        generation = 5
+        expiry = int(time.time()) + 300
+        hawk_id = (
+            base64.urlsafe_b64encode(f"{user_id}:{generation}:{expiry}".encode())
+            .decode()
+            .rstrip("=")
+        )
+        hawk_key = "a" * 64
+        method = "GET"
+        path = "/storage/bookmarks"
+        host = "api.example.com"
+        port = 443
+
+        authorization_header = build_hawk_auth_header(hawk_id, hawk_key, method, path, host, port)
+
+        # Token not found in cache
+        mock_dynamodb_table.get_item.return_value = {}
+
+        with pytest.raises(AuthenticationException, match="HAWK token not found"):
+            hawk_service.validate(authorization_header, method, path, host, port)
+
+    def test_validate_dynamodb_error(self, hawk_service, mock_dynamodb_table):
+        """Test validation when DynamoDB raises an error"""
+        user_id = "user123"
+        generation = 5
+        expiry = int(time.time()) + 300
+        hawk_id = (
+            base64.urlsafe_b64encode(f"{user_id}:{generation}:{expiry}".encode())
+            .decode()
+            .rstrip("=")
+        )
+        hawk_key = "a" * 64
+        method = "GET"
+        path = "/storage/bookmarks"
+        host = "api.example.com"
+        port = 443
+
+        authorization_header = build_hawk_auth_header(hawk_id, hawk_key, method, path, host, port)
+
+        # DynamoDB error
+        mock_dynamodb_table.get_item.side_effect = ClientError(
+            {"Error": {"Code": "ServiceUnavailable", "Message": "Service unavailable"}},
+            "GetItem",
+        )
+
+        with pytest.raises(AuthenticationException, match="Failed to retrieve HAWK token"):
+            hawk_service.validate(authorization_header, method, path, host, port)
+
+    def test_validate_missing_header(self, hawk_service):
+        """Test validation with missing authorization header"""
+        with pytest.raises(InvalidHawkHeaderException, match="must start with 'Hawk '"):
+            hawk_service.validate("", "GET", "/storage/bookmarks", "api.example.com", 443)
+
+    def test_validate_malformed_header(self, hawk_service):
+        """Test validation with malformed header (no Hawk prefix)"""
+        with pytest.raises(InvalidHawkHeaderException, match="must start with 'Hawk '"):
+            hawk_service.validate(
+                "Bearer token123", "GET", "/storage/bookmarks", "api.example.com", 443
+            )
+
+    def test_validate_bad_header_value(self, hawk_service, mock_dynamodb_table):
+        """Test validation with malformed Hawk header content (BadHeaderValue)"""
+        user_id = "user123"
+        generation = 5
+        expiry = int(time.time()) + 300
+        hawk_id = (
+            base64.urlsafe_b64encode(f"{user_id}:{generation}:{expiry}".encode())
+            .decode()
+            .rstrip("=")
+        )
+
+        # Header with an unparseable trailing field triggers BadHeaderValue in mohawk
+        authorization_header = f'Hawk id="{hawk_id}", ts="12345", nonce="n", mac="m", bad'
+
+        # Mock DynamoDB response (credentials_map needs to work)
         mock_dynamodb_table.get_item.return_value = {
             "Item": {
                 "hawk_key": "a" * 64,
@@ -625,12 +447,121 @@ class TestValidate:
             }
         }
 
-        with pytest.raises(InvalidHawkSignatureException) as exc_info:
+        with pytest.raises(InvalidHawkHeaderException):
             hawk_service.validate(
                 authorization_header, "GET", "/storage/bookmarks", "api.example.com", 443
             )
 
-        assert "MAC verification failed" in str(exc_info.value)
+    def test_validate_missing_authorization_from_mohawk(self, hawk_service, mock_dynamodb_table):
+        """Test MissingAuthorization exception path from mohawk.Receiver"""
+        user_id = "user123"
+        generation = 5
+        expiry = int(time.time()) + 300
+        hawk_id = (
+            base64.urlsafe_b64encode(f"{user_id}:{generation}:{expiry}".encode())
+            .decode()
+            .rstrip("=")
+        )
+        hawk_key = "a" * 64
+
+        authorization_header = build_hawk_auth_header(
+            hawk_id, hawk_key, "GET", "/storage/bookmarks", "api.example.com", 443
+        )
+
+        mock_dynamodb_table.get_item.return_value = {
+            "Item": {
+                "hawk_key": hawk_key,
+                "user_id": user_id,
+                "generation": generation,
+            }
+        }
+
+        with patch("src.services.hawk_service.mohawk.Receiver") as mock_receiver:
+            mock_receiver.side_effect = mohawk.exc.MissingAuthorization()
+            with pytest.raises(InvalidHawkHeaderException, match="Missing authorization"):
+                hawk_service.validate(
+                    authorization_header, "GET", "/storage/bookmarks", "api.example.com", 443
+                )
+
+    def test_validate_generic_hawk_fail(self, hawk_service, mock_dynamodb_table):
+        """Test generic HawkFail catch-all exception path"""
+        user_id = "user123"
+        generation = 5
+        expiry = int(time.time()) + 300
+        hawk_id = (
+            base64.urlsafe_b64encode(f"{user_id}:{generation}:{expiry}".encode())
+            .decode()
+            .rstrip("=")
+        )
+        hawk_key = "a" * 64
+
+        authorization_header = build_hawk_auth_header(
+            hawk_id, hawk_key, "GET", "/storage/bookmarks", "api.example.com", 443
+        )
+
+        mock_dynamodb_table.get_item.return_value = {
+            "Item": {
+                "hawk_key": hawk_key,
+                "user_id": user_id,
+                "generation": generation,
+            }
+        }
+
+        with patch("src.services.hawk_service.mohawk.Receiver") as mock_receiver:
+            mock_receiver.side_effect = mohawk.exc.InvalidCredentials("bad creds")
+            with pytest.raises(InvalidHawkSignatureException, match="bad creds"):
+                hawk_service.validate(
+                    authorization_header, "GET", "/storage/bookmarks", "api.example.com", 443
+                )
+
+    def test_validate_rejects_replayed_nonce(self, hawk_service, mock_dynamodb_table):
+        """Replayed nonce is rejected"""
+        user_id = "user1"
+        generation = 0
+        expiry = int(time.time()) + 300
+        hawk_id = hawk_service.generate_hawk_id(user_id, generation, expiry)
+        hawk_key = hawk_service.generate_hawk_key()
+        mock_dynamodb_table.get_item.return_value = {
+            "Item": {"hawk_key": hawk_key, "user_id": user_id, "generation": generation}
+        }
+        # Nonce already seen -- put_item raises ConditionalCheckFailedException
+        mock_dynamodb_table.put_item.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": ""}},
+            "PutItem",
+        )
+        header = build_hawk_auth_header(hawk_id, hawk_key, "GET", "/test", "host", 443)
+        with pytest.raises(InvalidHawkSignatureException):
+            hawk_service.validate(header, "GET", "/test", "host", 443)
+
+
+class TestSeenNonce:
+    """Tests for _seen_nonce method"""
+
+    def test_seen_nonce_new_nonce(self, hawk_service, mock_dynamodb_table):
+        """New nonce returns False (not seen before)"""
+        mock_dynamodb_table.put_item.return_value = {}
+        result = hawk_service._seen_nonce("sender1", "nonce1", "12345")
+        assert result is False
+        mock_dynamodb_table.put_item.assert_called_once()
+
+    def test_seen_nonce_replay_detected(self, hawk_service, mock_dynamodb_table):
+        """Replayed nonce returns True"""
+        mock_dynamodb_table.put_item.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": ""}},
+            "PutItem",
+        )
+        result = hawk_service._seen_nonce("sender1", "nonce1", "12345")
+        assert result is True
+
+    def test_seen_nonce_reraises_other_errors(self, hawk_service, mock_dynamodb_table):
+        """Non-conditional errors are re-raised"""
+        mock_dynamodb_table.put_item.side_effect = ClientError(
+            {"Error": {"Code": "InternalServerError", "Message": "Server error"}},
+            "PutItem",
+        )
+        with pytest.raises(ClientError) as exc_info:
+            hawk_service._seen_nonce("sender1", "nonce1", "12345")
+        assert exc_info.value.response["Error"]["Code"] == "InternalServerError"
 
 
 class TestGenerateHawkCredentials:


### PR DESCRIPTION
## Summary

- Replace all hand-rolled Hawk HMAC-SHA256 authentication with the `mohawk` library, eliminating ~500 lines of custom crypto code
- Add nonce replay protection via DynamoDB conditional writes with TTL auto-cleanup
- Rewrite `hawk_service.py` and `fxa_token_manager.py` to use `mohawk.Receiver` with `credentials_map` callbacks for DynamoDB credential lookup
- Consolidate duplicate code: shared `_verify_hawk` helper, shared `build_hawk_auth_header` test fixture
- Align frontend HMAC key encoding (raw bytes → hex string) with mohawk server-side expectations

## Changes

| File | Change |
|---|---|
| `lambda/pyproject.toml` | Add `mohawk==1.1.0` dependency |
| `lambda/src/services/hawk_service.py` | Delete 5 custom crypto methods, rewrite `validate()` with `mohawk.Receiver`, add `_seen_nonce` for replay protection |
| `lambda/src/services/fxa_token_manager.py` | Delete regex parser + manual HMAC, rewrite with `mohawk.Receiver`, extract `_verify_hawk` helper, add `_seen_nonce` |
| `frontend/src/lib/fxa-crypto.ts` | 2-line change: hex-encode derived key before HMAC signing |
| `tests/fixtures/integration.py` | Add shared `build_hawk_auth_header` helper |
| 5 test files | Import shared helper, add nonce replay stubs and tests |

**Net: 909 insertions, 1125 deletions (-216 lines)**

## Security improvements

- **Nonce replay protection**: Each nonce is stored in DynamoDB with a conditional write. Replayed requests within the 60s timestamp skew window are rejected. Records auto-expire via DynamoDB TTL (2x skew window).
- **Battle-tested MAC verification**: mohawk handles header parsing, normalized string construction, HMAC-SHA256, and constant-time comparison instead of custom code.

## Deployment note

Frontend and Lambda must deploy together — the FxA session Hawk key encoding changes from raw bytes to hex string on both sides. Users mid-login during deployment will need to refresh.

## Test plan

- [x] 922 tests passing, 100% coverage
- [x] Frontend builds cleanly (`npm run build`)
- [x] No `hashlib`/`hmac` imports remain in modified source files
- [x] Nonce replay detection tested for both storage and FxA Hawk flows
- [ ] Verify login flow works end-to-end after deploy
- [ ] Verify Firefox Sync storage operations work after deploy