### PR TITLE
fix: use request_context.domain_name for auth Hawk URI reconstruction

### DIFF
--- a/lambda/src/routes/auth/account_keys.py
+++ b/lambda/src/routes/auth/account_keys.py
@@ -8,6 +8,7 @@ from src.services.auth_account_manager import AuthAccountManager
 from src.services.fxa_crypto import derive_key_request_key, encrypt_key_bundle
 from src.services.fxa_token_manager import KEY_FETCH_TOKEN_INFO, FxATokenManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import extract_hawk_request_params
 
 
 class AccountKeysRoute(BaseRoute):
@@ -33,10 +34,7 @@ class AccountKeysRoute(BaseRoute):
         if not auth_header:
             return self._error(401, 110, "Missing or invalid authorization")
 
-        host = headers.get("host", "localhost")
-        port = headers.get("x-forwarded-port", "443")
-        method = event.http_method
-        path = event.path
+        method, path, host, port = extract_hawk_request_params(event)
 
         # Consume the key-fetch token with Hawk HMAC verification (single-use)
         token_data = self._token_manager.verify_keyfetch_hawk(auth_header, method, path, host, port)

--- a/lambda/src/routes/auth/account_profile.py
+++ b/lambda/src/routes/auth/account_profile.py
@@ -7,6 +7,7 @@ from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
 from src.services.auth_account_manager import AuthAccountManager
 from src.services.fxa_token_manager import FxATokenManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import extract_hawk_request_params
 
 
 class AccountProfileRoute(BaseRoute):
@@ -32,10 +33,7 @@ class AccountProfileRoute(BaseRoute):
         if not auth_header:
             return self._error(401, 110, "Missing or invalid authorization")
 
-        host = headers.get("host", "localhost")
-        port = headers.get("x-forwarded-port", "443")
-        method = event.http_method
-        path = event.path
+        method, path, host, port = extract_hawk_request_params(event)
 
         uid = self._token_manager.verify_session_hawk(auth_header, method, path, host, port)
         if uid is None:

--- a/lambda/src/routes/auth/oauth_authorization.py
+++ b/lambda/src/routes/auth/oauth_authorization.py
@@ -7,6 +7,7 @@ from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
 from src.services.fxa_token_manager import FxATokenManager
 from src.services.oauth_code_manager import OAuthCodeManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import extract_hawk_request_params
 
 
 class OAuthAuthorizationRoute(BaseRoute):
@@ -32,10 +33,7 @@ class OAuthAuthorizationRoute(BaseRoute):
         if not auth_header:
             return self._error(401, 110, "Missing or invalid authorization")
 
-        host = headers.get("host", "localhost")
-        port = headers.get("x-forwarded-port", "443")
-        method = event.http_method
-        path = event.path
+        method, path, host, port = extract_hawk_request_params(event)
 
         uid = self._token_manager.verify_session_hawk(auth_header, method, path, host, port)
         if uid is None:

--- a/lambda/src/routes/auth/oauth_token.py
+++ b/lambda/src/routes/auth/oauth_token.py
@@ -11,6 +11,7 @@ from src.services.fxa_token_manager import FxATokenManager
 from src.services.jwt_service import JWTService
 from src.services.oauth_code_manager import OAuthCodeManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import extract_hawk_request_params
 
 DEFAULT_TTL = 900  # 15 minutes
 MAX_TTL = 3600  # 1 hour maximum
@@ -195,10 +196,7 @@ class OAuthTokenRoute(BaseRoute):
         if not auth_header:
             return self._error(401, 110, "Missing or invalid authorization")
 
-        host = headers.get("host", "localhost")
-        port = headers.get("x-forwarded-port", "443")
-        method = event.http_method
-        path = event.path
+        method, path, host, port = extract_hawk_request_params(event)
 
         uid = self._token_manager.verify_session_hawk(auth_header, method, path, host, port)
         if uid is None:

--- a/lambda/src/routes/auth/scoped_key_data.py
+++ b/lambda/src/routes/auth/scoped_key_data.py
@@ -7,7 +7,7 @@ from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
 from src.services.auth_account_manager import AuthAccountManager
 from src.services.fxa_token_manager import FxATokenManager
 from src.shared.base_route import BaseRoute
-from src.shared.utils import json_dumps
+from src.shared.utils import extract_hawk_request_params, json_dumps
 
 
 class ScopedKeyDataRoute(BaseRoute):
@@ -33,10 +33,7 @@ class ScopedKeyDataRoute(BaseRoute):
         if not auth_header:
             return self._error(401, 110, "Missing or invalid authorization")
 
-        host = headers.get("host", "localhost")
-        port = headers.get("x-forwarded-port", "443")
-        method = event.http_method
-        path = event.path
+        method, path, host, port = extract_hawk_request_params(event)
 
         uid = self._token_manager.verify_session_hawk(auth_header, method, path, host, port)
         if uid is None:

--- a/lambda/src/routes/auth/session_destroy.py
+++ b/lambda/src/routes/auth/session_destroy.py
@@ -7,6 +7,7 @@ from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
 
 from src.services.fxa_token_manager import FxATokenManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import extract_hawk_request_params
 
 HAWK_ID_PATTERN = re.compile(r'id="([^"]+)"')
 
@@ -28,10 +29,7 @@ class SessionDestroyRoute(BaseRoute):
         if not auth_header:
             return self._error(401, 110, "Missing or invalid authorization")
 
-        host = headers.get("host", "localhost")
-        port = headers.get("x-forwarded-port", "443")
-        method = event.http_method
-        path = event.path
+        method, path, host, port = extract_hawk_request_params(event)
 
         uid = self._token_manager.verify_session_hawk(auth_header, method, path, host, port)
         if uid is None:

--- a/lambda/src/routes/auth/session_status.py
+++ b/lambda/src/routes/auth/session_status.py
@@ -6,6 +6,7 @@ from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
 
 from src.services.fxa_token_manager import FxATokenManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import extract_hawk_request_params
 
 
 class SessionStatusRoute(BaseRoute):
@@ -25,10 +26,7 @@ class SessionStatusRoute(BaseRoute):
         if not auth_header:
             return self._error(401, 110, "Missing or invalid authorization")
 
-        host = headers.get("host", "localhost")
-        port = headers.get("x-forwarded-port", "443")
-        method = event.http_method
-        path = event.path
+        method, path, host, port = extract_hawk_request_params(event)
 
         uid = self._token_manager.verify_session_hawk(auth_header, method, path, host, port)
         if uid is None:

--- a/lambda/src/shared/utils.py
+++ b/lambda/src/shared/utils.py
@@ -51,3 +51,28 @@ class DecimalEncoder(json.JSONEncoder):
 def json_dumps(obj, **kwargs) -> str:
     """JSON dumps wrapper that handles Decimal objects"""
     return json.dumps(obj, cls=DecimalEncoder, **kwargs)
+
+
+def extract_hawk_request_params(event) -> tuple[str, str, str, str]:
+    """Extract (method, path, host, port) for Hawk MAC verification.
+
+    Uses request_context.domain_name (the custom domain) rather than
+    the Host header, which may differ behind edge-optimized API Gateway.
+    Appends query string to path for correct Hawk MAC computation.
+    """
+    method = event.http_method
+    path = event.path
+
+    query_params = event.query_string_parameters
+    if query_params:
+        qs = "&".join(f"{k}={v}" for k, v in query_params.items())
+        path = f"{path}?{qs}"
+
+    try:
+        host = event.request_context.domain_name or "localhost"
+    except (KeyError, AttributeError):
+        host = (event.headers or {}).get("host", "localhost")
+
+    port = "443"
+
+    return method, path, host, port

--- a/lambda/tests/shared/test_utils.py
+++ b/lambda/tests/shared/test_utils.py
@@ -5,12 +5,14 @@ from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
+from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
 
 from src.shared.utils import (
     DecimalEncoder,
     datetime_decoder,
     datetime_encoder,
     decimal_to_float,
+    extract_hawk_request_params,
     float_to_decimal,
     get_weave_timestamp,
     json_dumps,
@@ -129,3 +131,70 @@ class TestJsonDumps:
         assert "10" in result
         assert "hello" in result
         assert "3.14" in result
+
+
+class TestExtractHawkRequestParams:
+    """Test extract_hawk_request_params helper"""
+
+    def test_extracts_domain_name_from_request_context(self):
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "POST",
+                "path": "/v1/oauth/token",
+                "headers": {"host": "wrong.example.com"},
+                "requestContext": {"domainName": "auth.prod.ffsync.layertwo.dev"},
+            }
+        )
+        method, path, host, port = extract_hawk_request_params(event)
+        assert method == "POST"
+        assert path == "/v1/oauth/token"
+        assert host == "auth.prod.ffsync.layertwo.dev"
+        assert port == "443"
+
+    def test_appends_query_string_to_path(self):
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "POST",
+                "path": "/v1/session/destroy",
+                "headers": {},
+                "queryStringParameters": {"service": "sync"},
+                "requestContext": {"domainName": "auth.example.com"},
+            }
+        )
+        method, path, host, port = extract_hawk_request_params(event)
+        assert path == "/v1/session/destroy?service=sync"
+
+    def test_falls_back_to_host_header_when_no_request_context(self):
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "GET",
+                "path": "/v1/session/status",
+                "headers": {"host": "fallback.example.com"},
+            }
+        )
+        method, path, host, port = extract_hawk_request_params(event)
+        assert host == "fallback.example.com"
+
+    def test_falls_back_to_localhost_when_no_host_or_context(self):
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "GET",
+                "path": "/v1/session/status",
+                "headers": {},
+            }
+        )
+        method, path, host, port = extract_hawk_request_params(event)
+        assert host == "localhost"
+
+    def test_no_query_string_when_none(self):
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "GET",
+                "path": "/v1/session/status",
+                "headers": {},
+                "queryStringParameters": None,
+                "requestContext": {"domainName": "auth.example.com"},
+            }
+        )
+        _, path, _, _ = extract_hawk_request_params(event)
+        assert path == "/v1/session/status"


### PR DESCRIPTION
## Summary

- All 7 auth routes using session Hawk authentication extracted the host from `headers["host"]`, which through edge-optimized API Gateway + CloudFront returns the internal domain, not the custom domain (`auth.prod.ffsync.layertwo.dev`) Firefox used to compute the Hawk MAC — causing every `fxa-credentials` grant and session-authenticated request to return 401
- Added shared `extract_hawk_request_params()` helper in `shared/utils.py` that uses `request_context.domain_name` (matching the working storage HAWK authorizer pattern), hardcodes port 443, and appends query strings to the path
- Updated all 7 affected routes: `oauth_token`, `oauth_authorization`, `session_destroy`, `session_status`, `account_profile`, `account_keys`, `scoped_key_data`

## Test plan

- [x] 927 tests pass, 100% coverage
- [x] black, isort, flake8, mypy all clean
- [ ] Deploy and verify `/v1/oauth/token` with `fxa-credentials` grant returns 200
- [ ] Verify `/v1/session/destroy?service=sync` returns 200
- [ ] Verify `/v1/account/profile` returns 200
- [ ] Full Firefox Sync login + sync cycle completes without 401 errors