### PR TITLE
fix: add diagnostic logging to Hawk session verification

### DIFF
--- a/lambda/src/services/fxa_token_manager.py
+++ b/lambda/src/services/fxa_token_manager.py
@@ -5,9 +5,12 @@ from typing import Optional
 
 import mohawk
 import mohawk.exc
+from aws_lambda_powertools import Logger
 from botocore.exceptions import ClientError
 
 from src.services import fxa_crypto
+
+logger = Logger(child=True)
 
 _PK = "PK"
 SESSION_TOKEN_INFO = "identity.mozilla.com/picl/v1/sessionToken"
@@ -128,18 +131,31 @@ class FxATokenManager:
         """
         if not authorization_header:
             return False
+        uri = f"https://{host}:{port}{path}"
         try:
             mohawk.Receiver(
                 credentials_map,
                 authorization_header,
-                f"https://{host}:{port}{path}",
+                uri,
                 method,
                 seen_nonce=self._seen_nonce,
                 accept_untrusted_content=True,
                 timestamp_skew_in_seconds=60,
             )
             return True
-        except mohawk.exc.HawkFail:
+        except mohawk.exc.HawkFail as e:
+            logger.warning(
+                "Hawk verification failed",
+                extra={
+                    "error_type": type(e).__name__,
+                    "error": str(e),
+                    "uri": uri,
+                    "method": method,
+                    "host": host,
+                    "port": port,
+                    "path": path,
+                },
+            )
             return False
 
     def verify_session_hawk(

--- a/lambda/src/shared/utils.py
+++ b/lambda/src/shared/utils.py
@@ -60,6 +60,10 @@ def extract_hawk_request_params(event) -> tuple[str, str, str, str]:
     the Host header, which may differ behind edge-optimized API Gateway.
     Appends query string to path for correct Hawk MAC computation.
     """
+    from aws_lambda_powertools import Logger
+
+    _logger = Logger(child=True)
+
     method = event.http_method
     path = event.path
 
@@ -68,11 +72,25 @@ def extract_hawk_request_params(event) -> tuple[str, str, str, str]:
         qs = "&".join(f"{k}={v}" for k, v in query_params.items())
         path = f"{path}?{qs}"
 
+    headers = event.headers or {}
+    host_header = headers.get("host", "")
+
     try:
         host = event.request_context.domain_name or "localhost"
     except (KeyError, AttributeError):
-        host = (event.headers or {}).get("host", "localhost")
+        host = host_header or "localhost"
 
     port = "443"
+
+    _logger.debug(
+        "Hawk request params",
+        extra={
+            "method": method,
+            "path": path,
+            "domain_name": host,
+            "host_header": host_header,
+            "port": port,
+        },
+    )
 
     return method, path, host, port


### PR DESCRIPTION
## Summary

- The previous fix (#242) didn't resolve the `/v1/oauth/token` 401 errors — session Hawk auth still fails after sign-out/sign-in
- Adds diagnostic logging to pinpoint the exact failure cause:
  - `_verify_hawk`: logs the specific `HawkFail` subclass (`MacMismatch`, `CredentialsLookupError`, `TokenExpired`), plus the full URI, method, host, and port used for verification
  - `extract_hawk_request_params`: logs `domain_name` (from `request_context`) vs `host_header` (from `Host` header) to confirm whether they differ

## Test plan

- [x] 927 tests pass, 100% coverage
- [x] black, isort, flake8 clean
- [ ] Deploy, trigger Firefox sync, check CloudWatch logs for `ffsync-auth-api-prod`:
  - Search for `"Hawk verification failed"` to see the error type and URI
  - Search for `"Hawk request params"` to see domain_name vs host_header