### PR TITLE
fix: add Hawk session diagnostic logging for MacMismatch

### DIFF
--- a/lambda/src/services/fxa_token_manager.py
+++ b/lambda/src/services/fxa_token_manager.py
@@ -154,6 +154,9 @@ class FxATokenManager:
                     "host": host,
                     "port": port,
                     "path": path,
+                    "auth_header_prefix": (
+                        authorization_header[:120] if authorization_header else ""
+                    ),
                 },
             )
             return False
@@ -170,6 +173,13 @@ class FxATokenManager:
         uid_holder = {}
 
         def credentials_map(sender_id):
+            logger.info(
+                "Session Hawk credential lookup",
+                extra={
+                    "sender_id_prefix": sender_id[:16],
+                    "pk": f"{SESSION_PREFIX}#{sender_id[:16]}...",
+                },
+            )
             response = self.table.get_item(Key={_PK: f"{SESSION_PREFIX}#{sender_id}"})
             if "Item" not in response:
                 raise mohawk.exc.CredentialsLookupError("Session not found")
@@ -180,6 +190,10 @@ class FxATokenManager:
             if not key:
                 raise mohawk.exc.CredentialsLookupError("Missing HMAC key")
             uid_holder["uid"] = item["uid"]
+            logger.info(
+                "Session Hawk credentials found",
+                extra={"key_prefix": key[:16], "key_len": len(key), "uid": item["uid"]},
+            )
             return {"id": sender_id, "key": key, "algorithm": "sha256"}
 
         if not self._verify_hawk(authorization_header, method, path, host, port, credentials_map):

--- a/lambda/src/services/fxa_token_manager.py
+++ b/lambda/src/services/fxa_token_manager.py
@@ -5,9 +5,12 @@ from typing import Optional
 
 import mohawk
 import mohawk.exc
+from aws_lambda_powertools import Logger
 from botocore.exceptions import ClientError
 
 from src.services import fxa_crypto
+
+logger = Logger(child=True)
 
 _PK = "PK"
 SESSION_TOKEN_INFO = "identity.mozilla.com/picl/v1/sessionToken"
@@ -128,18 +131,31 @@ class FxATokenManager:
         """
         if not authorization_header:
             return False
+        uri = f"https://{host}:{port}{path}"
         try:
             mohawk.Receiver(
                 credentials_map,
                 authorization_header,
-                f"https://{host}:{port}{path}",
+                uri,
                 method,
                 seen_nonce=self._seen_nonce,
                 accept_untrusted_content=True,
                 timestamp_skew_in_seconds=60,
             )
             return True
-        except mohawk.exc.HawkFail:
+        except mohawk.exc.HawkFail as e:
+            logger.warning(
+                "Hawk verification failed",
+                extra={
+                    "error_type": type(e).__name__,
+                    "error": str(e),
+                    "uri": uri,
+                    "method": method,
+                    "host": host,
+                    "port": port,
+                    "path": path,
+                },
+            )
             return False
 
     def verify_session_hawk(

--- a/lambda/src/shared/utils.py
+++ b/lambda/src/shared/utils.py
@@ -60,6 +60,10 @@ def extract_hawk_request_params(event) -> tuple[str, str, str, str]:
     the Host header, which may differ behind edge-optimized API Gateway.
     Appends query string to path for correct Hawk MAC computation.
     """
+    from aws_lambda_powertools import Logger
+
+    _logger = Logger(child=True)
+
     method = event.http_method
     path = event.path
 
@@ -68,11 +72,25 @@ def extract_hawk_request_params(event) -> tuple[str, str, str, str]:
         qs = "&".join(f"{k}={v}" for k, v in query_params.items())
         path = f"{path}?{qs}"
 
+    headers = event.headers or {}
+    host_header = headers.get("host", "")
+
     try:
         host = event.request_context.domain_name or "localhost"
     except (KeyError, AttributeError):
-        host = (event.headers or {}).get("host", "localhost")
+        host = host_header or "localhost"
 
     port = "443"
+
+    _logger.debug(
+        "Hawk request params",
+        extra={
+            "method": method,
+            "path": path,
+            "domain_name": host,
+            "host_header": host_header,
+            "port": port,
+        },
+    )
 
     return method, path, host, port


### PR DESCRIPTION
## Summary

- The host/port/path fix (#242) resolved URI construction but the `MacMismatch` persists — credentials ARE found in DynamoDB but the MACs don't match
- Adds detailed logging to trace the exact mismatch:
  - **Credential lookup**: tokenId prefix, stored key prefix + length, uid — confirms the right session is found
  - **Hawk failure**: Authorization header prefix — shows what Firefox actually sent (including whether it includes a content `hash`)
  - **Request params**: domain_name vs Host header comparison

## What we know so far

- `error_type: MacMismatch` — session found, key retrieved, but MACs differ
- URI is correct: `https://auth.prod.ffsync.layertwo.dev:443/v1/oauth/token`
- Roundtrip test passes (same-code client+server crypto works)
- Suspect: Firefox may derive different Hawk credentials from the sessionToken, or content hash handling differs

## Test plan

- [x] 927 tests pass, 100% coverage
- [ ] Deploy, trigger sync, check CloudWatch for `"Session Hawk credentials found"` and `"Hawk verification failed"`