### PR TITLE
fix: add credential lookup logging for Hawk MacMismatch

### DIFF
--- a/lambda/src/services/fxa_token_manager.py
+++ b/lambda/src/services/fxa_token_manager.py
@@ -154,6 +154,9 @@ class FxATokenManager:
                     "host": host,
                     "port": port,
                     "path": path,
+                    "auth_header_prefix": (
+                        authorization_header[:120] if authorization_header else ""
+                    ),
                 },
             )
             return False
@@ -170,6 +173,13 @@ class FxATokenManager:
         uid_holder = {}
 
         def credentials_map(sender_id):
+            logger.info(
+                "Session Hawk credential lookup",
+                extra={
+                    "sender_id_prefix": sender_id[:16],
+                    "pk": f"{SESSION_PREFIX}#{sender_id[:16]}...",
+                },
+            )
             response = self.table.get_item(Key={_PK: f"{SESSION_PREFIX}#{sender_id}"})
             if "Item" not in response:
                 raise mohawk.exc.CredentialsLookupError("Session not found")
@@ -180,6 +190,10 @@ class FxATokenManager:
             if not key:
                 raise mohawk.exc.CredentialsLookupError("Missing HMAC key")
             uid_holder["uid"] = item["uid"]
+            logger.info(
+                "Session Hawk credentials found",
+                extra={"key_prefix": key[:16], "key_len": len(key), "uid": item["uid"]},
+            )
             return {"id": sender_id, "key": key, "algorithm": "sha256"}
 
         if not self._verify_hawk(authorization_header, method, path, host, port, credentials_map):


### PR DESCRIPTION
## Summary

- Adds detailed logging to the session Hawk credential lookup to diagnose the persistent `MacMismatch` error
- Logs on credential lookup: tokenId prefix, DynamoDB key prefix
- Logs on credentials found: stored key prefix (first 16 chars), key length, uid
- Logs on failure: first 120 chars of the Authorization header (shows whether Firefox sends a `hash=` field)

## Context

PR #246 confirmed `MacMismatch` — the session IS found in DynamoDB but the computed MACs differ. The URI is correct. This logging will reveal:
1. Whether the right session is being looked up
2. The stored key characteristics
3. Whether Firefox includes a content hash in the Hawk header

## Test plan

- [x] 927 tests pass, 100% coverage
- [x] black, isort, flake8 clean
- [ ] Deploy, trigger sync, check CloudWatch for the three log entries