### PR TITLE
chore: replace aws-lambda-python-alpha with uv-python-lambda

### DIFF
--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   diff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       id-token: write
@@ -54,10 +54,6 @@ jobs:
 
       - name: Build TypeScript
         run: npm run build
-
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     permissions:
       contents: read
@@ -47,10 +47,6 @@ jobs:
 
       - name: Build TypeScript
         run: npm run build
-
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: CDK synth
         run: npx cdk synth --all --output build/cdk.out

--- a/lib/stacks/service.ts
+++ b/lib/stacks/service.ts
@@ -1,4 +1,4 @@
-import {PythonFunction} from "@aws-cdk/aws-lambda-python-alpha";
+import {PythonFunction} from "uv-python-lambda";
 import {Construct} from "constructs";
 import {readFileSync} from "fs";
 import * as path from "path";
@@ -207,7 +207,7 @@ export class ServiceStack extends Stack {
 
     private buildHawkAuthorizerHandler(): PythonFunction {
         const fn = new PythonFunction(this, "HawkAuthorizerHandler", {
-            entry: path.join(__dirname, "../../lambda"),
+            rootDir: path.join(__dirname, "../../lambda"),
             index: "src/entrypoint/__init__.py",
             runtime: Runtime.PYTHON_3_14,
             architecture: Architecture.ARM_64,
@@ -221,6 +221,9 @@ export class ServiceStack extends Stack {
                 HAWK_TIMESTAMP_SKEW_TOLERANCE: "60",
                 TOKEN_DURATION: "300",
             },
+            bundling: {
+                assetExcludes: [".venv/", ".git/", "tests/", "htmlcov/", ".pytest_cache/", ".mypy_cache/"],
+            },
         });
 
         // Grant read/write permissions to token cache table (read for credential
@@ -233,7 +236,7 @@ export class ServiceStack extends Stack {
 
     private buildStorageApiHandler(): PythonFunction {
         const fn = new PythonFunction(this, "ApiHandler", {
-            entry: path.join(__dirname, "../../lambda"),
+            rootDir: path.join(__dirname, "../../lambda"),
             index: "src/entrypoint/__init__.py",
             runtime: Runtime.PYTHON_3_14,
             architecture: Architecture.ARM_64,
@@ -245,6 +248,9 @@ export class ServiceStack extends Stack {
                 STAGE: this.props.stageType.toLowerCase(),
                 BASE_DOMAIN: this.stageBaseDomain,
                 STORAGE_TABLE_NAME: this.storageTable.tableName,
+            },
+            bundling: {
+                assetExcludes: [".venv/", ".git/", "tests/", "htmlcov/", ".pytest_cache/", ".mypy_cache/"],
             },
         });
 
@@ -258,7 +264,7 @@ export class ServiceStack extends Stack {
 
     private buildAuthApiHandler(): PythonFunction {
         const fn = new PythonFunction(this, "AuthApiHandler", {
-            entry: path.join(__dirname, "../../lambda"),
+            rootDir: path.join(__dirname, "../../lambda"),
             index: "src/entrypoint/__init__.py",
             runtime: Runtime.PYTHON_3_14,
             architecture: Architecture.ARM_64,
@@ -280,6 +286,9 @@ export class ServiceStack extends Stack {
                 HAWK_TIMESTAMP_SKEW_TOLERANCE: "60",
                 RETRY_AFTER_SECONDS: "30",
                 TOKEN_DURATION: "300",
+            },
+            bundling: {
+                assetExcludes: [".venv/", ".git/", "tests/", "htmlcov/", ".pytest_cache/", ".mypy_cache/"],
             },
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
             "name": "@layertwo/ffsync",
             "version": "0.1.0",
             "dependencies": {
-                "@aws-cdk/aws-lambda-python-alpha": "^2.240.0-alpha.0",
                 "aws-cdk": "^2.1106.0",
                 "aws-cdk-lib": "^2.240.0",
                 "cdk-monitoring-constructs": "^9.19.2",
                 "constructs": "^10.5.1",
                 "env-var": "^7.0.0",
-                "source-map-support": "^0.5.16"
+                "source-map-support": "^0.5.16",
+                "uv-python-lambda": "^0.0.7"
             },
             "devDependencies": {
                 "@stylistic/eslint-plugin-js": "^4.0.0",
@@ -45,19 +45,6 @@
             "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
             "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
             "license": "Apache-2.0"
-        },
-        "node_modules/@aws-cdk/aws-lambda-python-alpha": {
-            "version": "2.240.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.240.0-alpha.0.tgz",
-            "integrity": "sha512-F78aTyzdmiDm7aNDVsTPyzHAU0ZLZK9bFZcMJziWcFz3zmPTzHMQX5/TdVz8uhQ6EMpSkUIrJvMOGOs0KLHM+Q==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">= 18.0.0"
-            },
-            "peerDependencies": {
-                "aws-cdk-lib": "^2.240.0",
-                "constructs": "^10.5.0"
-            }
         },
         "node_modules/@aws-cdk/cloud-assembly-schema": {
             "version": "50.4.0",
@@ -6523,6 +6510,16 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/uv-python-lambda": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/uv-python-lambda/-/uv-python-lambda-0.0.7.tgz",
+            "integrity": "sha512-POUnoBfbdMp7HjvwfwVEAxXPk5On8L5QKjDCg25OFBO7+qa0kPyID1CqvCye92MzmA8Q4pNIeJ51dBH9K5C8Cg==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "aws-cdk-lib": "^2.161.1",
+                "constructs": "^10.3.0"
             }
         },
         "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "watch": "tsc -w"
     },
     "dependencies": {
-        "@aws-cdk/aws-lambda-python-alpha": "^2.240.0-alpha.0",
+        "uv-python-lambda": "^0.0.7",
         "aws-cdk": "^2.1106.0",
         "aws-cdk-lib": "^2.240.0",
         "cdk-monitoring-constructs": "^9.19.2",


### PR DESCRIPTION
## Summary
- Replaces `@aws-cdk/aws-lambda-python-alpha` with [`uv-python-lambda`](https://github.com/fourTheorem/uv-python-lambda) (v0.0.7) for faster Lambda bundling using `uv`
- Updates all 3 `PythonFunction` constructs (`entry` → `rootDir`)
- Adds `bundling.assetExcludes` to skip `.venv/`, `.git/`, `tests/`, `htmlcov/`, `.pytest_cache/`, `.mypy_cache/` from assets

## Why
The alpha CDK construct uses pip for dependency resolution inside Docker, which is slow. `uv-python-lambda` uses `uv` instead, which is significantly faster for installs and resolution. The existing `uv.lock` in `lambda/` is picked up automatically for deterministic builds.

## Test plan
- [ ] CDK diff shows no unexpected infrastructure changes (Lambda replacement is expected)
- [ ] CDK synth completes successfully
- [ ] Deployed Lambda functions start and respond correctly