### PR TITLE
ci: parallelize workflow jobs and skip frontend in cdk-diff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,92 @@
+name: build
+
+on:
+  workflow_call:
+
+jobs:
+  smithy:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 17
+          cache: gradle
+
+      - name: Build Smithy model
+        working-directory: smithy
+        run: ./gradlew smithyBuild
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: smithy-output
+          path: build/smithy
+          retention-days: 1
+
+  frontend:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm ci && npm run build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          retention-days: 1
+
+  synth:
+    needs: [smithy, frontend]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: smithy-output
+          path: build/smithy
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: CDK synth
+        run: npx cdk synth --all --output build/cdk.out
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cdk-out
+          path: build/cdk.out
+          retention-days: 1

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -46,8 +46,32 @@ jobs:
           path: build/smithy
           retention-days: 1
 
+  frontend:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm ci && npm run build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          retention-days: 1
+
   diff:
-    needs: smithy
+    needs: [smithy, frontend]
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     permissions:
@@ -69,6 +93,11 @@ jobs:
         with:
           name: smithy-output
           path: build/smithy
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: frontend-dist
+          path: frontend/dist
 
       - name: Build TypeScript
         run: npm run build

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -5,6 +5,7 @@ on:
     branches: [mainline]
     paths:
       - 'lib/**'
+      - 'lambda/**'
       - 'smithy/**'
       - '.github/workflows/cdk-diff.yml'
       - 'package.json'
@@ -21,12 +22,9 @@ env:
   STAGE: "prod"
 
 jobs:
-  diff:
+  smithy:
     runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: write
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -36,6 +34,27 @@ jobs:
           java-version: 17
           cache: gradle
 
+      - name: Build Smithy model
+        working-directory: smithy
+        run: ./gradlew smithyBuild
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: smithy-output
+          path: build/smithy
+          retention-days: 1
+
+  diff:
+    needs: smithy
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -44,13 +63,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Smithy model
-        working-directory: smithy
-        run: ./gradlew smithyBuild
-
-      - name: Build frontend
-        working-directory: frontend
-        run: npm ci && npm run build
+      - uses: actions/download-artifact@v8
+        with:
+          name: smithy-output
+          path: build/smithy
 
       - name: Build TypeScript
         run: npm run build
@@ -62,7 +78,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: CDK Synthesize
-        run: npx cdk synth --all --output build/cdk.out
+        run: npx cdk synth Service-prod Monitoring-prod --output build/cdk.out
 
       - name: CDK Diff
         uses: corymhall/cdk-diff-action@v2

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -7,6 +7,7 @@ on:
       - 'lib/**'
       - 'lambda/**'
       - 'smithy/**'
+      - '.github/workflows/build.yml'
       - '.github/workflows/cdk-diff.yml'
       - 'package.json'
       - 'package-lock.json'
@@ -22,56 +23,11 @@ env:
   STAGE: "prod"
 
 jobs:
-  smithy:
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: corretto
-          java-version: 17
-          cache: gradle
-
-      - name: Build Smithy model
-        working-directory: smithy
-        run: ./gradlew smithyBuild
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: smithy-output
-          path: build/smithy
-          retention-days: 1
-
-  frontend:
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Build frontend
-        working-directory: frontend
-        run: npm ci && npm run build
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: frontend-dist
-          path: frontend/dist
-          retention-days: 1
+  build:
+    uses: ./.github/workflows/build.yml
 
   diff:
-    needs: [smithy, frontend]
+    needs: build
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     permissions:
@@ -91,25 +47,13 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: smithy-output
-          path: build/smithy
+          name: cdk-out
+          path: build/cdk.out
 
-      - uses: actions/download-artifact@v8
-        with:
-          name: frontend-dist
-          path: frontend/dist
-
-      - name: Build TypeScript
-        run: npm run build
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.CDK_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: CDK Synthesize
-        run: npx cdk synth Service-prod Monitoring-prod --output build/cdk.out
 
       - name: CDK Diff
         uses: corymhall/cdk-diff-action@v2

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -25,6 +25,8 @@ jobs:
   smithy:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
   smithy:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -39,6 +41,8 @@ jobs:
   frontend:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,96 +14,11 @@ env:
   STAGE: "prod"
 
 jobs:
-  smithy:
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: corretto
-          java-version: 17
-          cache: gradle
-
-      - name: Build Smithy model
-        working-directory: smithy
-        run: ./gradlew smithyBuild
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: smithy-output
-          path: build/smithy
-          retention-days: 1
-
-  frontend:
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Build frontend
-        working-directory: frontend
-        run: npm ci && npm run build
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: frontend-dist
-          path: frontend/dist
-          retention-days: 1
-
-  synth:
-    needs: [smithy, frontend]
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: smithy-output
-          path: build/smithy
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: frontend-dist
-          path: frontend/dist
-
-      - name: Build TypeScript
-        run: npm run build
-
-      - name: CDK synth
-        run: npx cdk synth --all --output build/cdk.out
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: cdk-out
-          path: build/cdk.out
-          retention-days: 1
+  build:
+    uses: ./.github/workflows/build.yml
 
   deploy:
-    needs: synth
+    needs: build
     runs-on: ubuntu-latest
     environment: prod
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,12 +14,9 @@ env:
   STAGE: "prod"
 
 jobs:
-  build:
+  smithy:
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -29,6 +26,48 @@ jobs:
           java-version: 17
           cache: gradle
 
+      - name: Build Smithy model
+        working-directory: smithy
+        run: ./gradlew smithyBuild
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: smithy-output
+          path: build/smithy
+          retention-days: 1
+
+  frontend:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm ci && npm run build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          retention-days: 1
+
+  synth:
+    needs: [smithy, frontend]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -37,13 +76,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Smithy model
-        working-directory: smithy
-        run: ./gradlew smithyBuild
+      - uses: actions/download-artifact@v8
+        with:
+          name: smithy-output
+          path: build/smithy
 
-      - name: Build frontend
-        working-directory: frontend
-        run: npm ci && npm run build
+      - uses: actions/download-artifact@v8
+        with:
+          name: frontend-dist
+          path: frontend/dist
 
       - name: Build TypeScript
         run: npm run build
@@ -58,7 +99,7 @@ jobs:
           retention-days: 1
 
   deploy:
-    needs: build
+    needs: synth
     runs-on: ubuntu-latest
     environment: prod
     permissions:


### PR DESCRIPTION
## Summary
- Extract a shared **`build.yml`** reusable workflow with parallel `smithy`, `frontend`, and `synth` jobs running on native ARM runners
- **`deploy.yml`** and **`cdk-diff.yml`** both call `build.yml`, then run their own final job (deploy or diff)
- Add `lambda/**` to cdk-diff paths filter so Lambda code changes trigger diffs
- Add explicit `permissions: contents: read` to all jobs

## Before → After

### Before (deploy)
```
build (sequential: java setup → smithy → frontend → tsc → synth) → deploy
```

### After (deploy)
```
build.yml:
  smithy ─┐
           ├→ synth → deploy
  frontend ┘
```

### Before (cdk-diff)
```
diff (sequential: java setup → smithy → frontend → tsc → synth → diff)
```

### After (cdk-diff)
```
build.yml:
  smithy ─┐
           ├→ synth → diff
  frontend ┘
```

## Test plan
- [ ] cdk-diff workflow passes on this PR
- [ ] Deploy workflow runs successfully after merge