### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
 
   deploy:


### PR DESCRIPTION
Potential fix for [https://github.com/layertwo/ffsync/security/code-scanning/6](https://github.com/layertwo/ffsync/security/code-scanning/6)

In general, the fix is to explicitly define `permissions` for every job or at the workflow root so that the `GITHUB_TOKEN` is scoped to the least privileges the job needs. Since the warning is on the `build` job invocation that uses the reusable workflow, we should add a `permissions` block under that job to avoid inheriting broad defaults.

The best minimal fix, without changing existing functionality, is to add a conservative permissions block to the `build` job, for example limiting it to read‑only repository contents. Because we don’t see what `build.yml` does, we must avoid granting too little and breaking it; the standard safe baseline is `contents: read`, which aligns with GitHub’s recommended minimal starting point and is highly unlikely to interfere with a typical build that just needs to read the code and artifacts. This change is localized to `.github/workflows/deploy.yml`, lines 17–19: we will insert a `permissions:` section under `build:`. No imports or additional definitions are needed, as this is pure workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
