### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -14,6 +14,9 @@ on:
       - 'cdk.json'
       - 'cdk.context.json'
 
+permissions:
+  contents: read
+
 concurrency:
   group: cdk-diff-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/layertwo/ffsync/security/code-scanning/5](https://github.com/layertwo/ffsync/security/code-scanning/5)

In general, the fix is to define an explicit `permissions` block, either at the workflow root (applies to all jobs without their own `permissions`) or directly on the affected job. Since the `diff` job already specifies its permissions and the `build` job does not, the best fix is to add a minimal, read-only `permissions` block at the root of the workflow. This ensures `build` runs with restricted GITHUB_TOKEN permissions, while `diff` continues using its own, more permissive configuration.

Concretely, in `.github/workflows/cdk-diff.yml`, insert a new root-level `permissions` section after the `on:` block and before `concurrency:`. Use least-privilege read-only permissions that are safe for a typical build workflow, e.g.:

```yaml
permissions:
  contents: read
```

This will apply to `build` (which currently has no explicit `permissions`) and will not affect `diff`, because job-level permissions override workflow-level ones. No imports or other definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
