### PR TITLE
fix: add diagnostic logging for Hawk query string ordering

### DIFF
--- a/lambda/src/services/hawk_service.py
+++ b/lambda/src/services/hawk_service.py
@@ -106,6 +106,14 @@ class HawkService:
         except mohawk.exc.BadHeaderValue as e:
             raise InvalidHawkHeaderException(str(e))
         except mohawk.exc.MacMismatch:
+            logger.error(
+                "HAWK MAC mismatch — query string ordering issue?",
+                extra={
+                    "method": method,
+                    "server_url": f"https://{host}:{port}{path}",
+                    "path": path,
+                },
+            )
             raise InvalidHawkSignatureException("HAWK MAC verification failed")
         except mohawk.exc.TokenExpired:
             raise InvalidHawkSignatureException("Timestamp outside acceptable window")

--- a/lambda/src/shared/utils.py
+++ b/lambda/src/shared/utils.py
@@ -1,6 +1,9 @@
 import json
+import logging
 from datetime import datetime, timezone
 from decimal import Decimal
+
+logger = logging.getLogger(__name__)
 
 
 def datetime_encoder(dt: datetime) -> Decimal:
@@ -65,8 +68,17 @@ def extract_hawk_request_params(event) -> tuple[str, str, str, int]:
 
     query_params = event.query_string_parameters
     if query_params:
+        param_keys = list(query_params.keys())
         qs = "&".join(f"{k}={v}" for k, v in query_params.items())
         path = f"{path}?{qs}"
+        logger.info(
+            "Hawk query string reconstruction",
+            extra={
+                "original_path": event.path,
+                "reconstructed_path": path,
+                "param_key_order": param_keys,
+            },
+        )
 
     try:
         host = event.request_context.domain_name or "localhost"


### PR DESCRIPTION
## Summary

- Log reconstructed query string param order and full server URL on Hawk MAC mismatch
- Diagnoses storage 401 failures on `GET /storage/prefs?newer=...&full=1&limit=1000`

## Context

Storage sync fails with 401 on the `prefs` collection but succeeds for `clients`, `meta/global`, `crypto/keys`, etc. All use the same Hawk token.

**Hypothesis:** `extract_hawk_request_params` reconstructs the query string from `event.query_string_parameters` (a dict), which loses the original parameter ordering from the HTTP request. API Gateway REST API v1 may serialize dict keys alphabetically:

| Request | Client order | Server order (if alphabetized) | MAC match? |
|---------|-------------|-------------------------------|-----------|
| `clients?full=1&limit=1000` | `full,limit` | `full,limit` | Yes → 200 |
| `prefs?newer=...&full=1&limit=1000` | `newer,full,limit` | `full,limit,newer` | **No → 401** |

## What to look for in CloudWatch

- `"Hawk query string reconstruction"` — check `param_key_order` on prefs requests
- `"HAWK MAC mismatch"` — confirms which URL mohawk tried to verify

## Test plan

- [ ] Deploy to prod
- [ ] Trigger a sync from Firefox
- [ ] Check CloudWatch logs for the prefs request's `param_key_order`
- [ ] If confirmed, follow up with a fix (HTTP API v2 for `rawQueryString`, or alternative)