### PR TITLE
feat: expand CloudWatch dashboard to monitor all services

### DIFF
--- a/lib/app.ts
+++ b/lib/app.ts
@@ -23,15 +23,7 @@ new GitHubOidcStack(app, "GitHubOidcStack", {
         stageType,
     });
 
-    new MonitoringStack(app, `Monitoring-${stageType.toLowerCase()}`, {
-        env,
-        stageType,
-        storageApi: serviceStack.storageApi,
-        storageHandler: serviceStack.storageHandler,
-        storageTable: serviceStack.storageTable,
-    });
-
-    new FrontendStack(app, `Frontend-${stageType.toLowerCase()}`, {
+    const frontendStack = new FrontendStack(app, `Frontend-${stageType.toLowerCase()}`, {
         env,
         stageType,
         authApiDomain: serviceStack.authApiDomain,
@@ -39,6 +31,25 @@ new GitHubOidcStack(app, "GitHubOidcStack", {
         profileApiDomain: serviceStack.profileApiDomain,
         oidcProviderUrl: serviceStack.oidcProviderUrlParam,
         clientId: serviceStack.clientIdParam,
+    });
+
+    new MonitoringStack(app, `Monitoring-${stageType.toLowerCase()}`, {
+        env,
+        stageType,
+        authApi: serviceStack.authApi,
+        authHandler: serviceStack.authHandler,
+        authTable: serviceStack.authTable,
+        tokenApi: serviceStack.tokenApi,
+        tokenHandler: serviceStack.tokenHandler,
+        tokenUsersTable: serviceStack.tokenUsersTable,
+        tokenCacheTable: serviceStack.tokenCacheTable,
+        profileApi: serviceStack.profileApi,
+        profileHandler: serviceStack.profileHandler,
+        storageApi: serviceStack.storageApi,
+        storageHandler: serviceStack.storageHandler,
+        storageTable: serviceStack.storageTable,
+        distribution: frontendStack.distribution,
+        wellKnownFunction: frontendStack.wellKnownFunction,
     });
 });
 

--- a/lib/stacks/frontend.ts
+++ b/lib/stacks/frontend.ts
@@ -37,6 +37,7 @@ export class FrontendStack extends Stack {
     private readonly bucket: Bucket;
     private readonly certificate: Certificate;
     public readonly distribution: Distribution;
+    public readonly wellKnownFunction: CfFunction;
 
     private get domainName(): string {
         return `${this.props.stageType.toLowerCase()}.${BASE_DOMAIN}`;
@@ -52,6 +53,7 @@ export class FrontendStack extends Stack {
         });
         this.bucket = this.buildBucket()
         this.certificate = this.buildCertificate();
+        this.wellKnownFunction = this.buildWellKnownFunction();
 
         this.distribution = this.buildDistribution();
     }
@@ -77,7 +79,7 @@ export class FrontendStack extends Stack {
         });
     }
 
-    private buildDistribution(): Distribution {
+    private buildWellKnownFunction(): CfFunction {
         const configJson = JSON.stringify({
             auth_server_base_url: `https://${this.props.authApiDomain}`,
             oauth_server_base_url: `https://${this.props.authApiDomain}`,
@@ -86,7 +88,7 @@ export class FrontendStack extends Stack {
             content_url: `https://${this.domainName}`,
         });
 
-        const wellKnownFn = new CfFunction(this, "WellKnownFunction", {
+        return new CfFunction(this, "WellKnownFunction", {
             code: FunctionCode.fromInline([
                 "function handler(event) {",
                 "  if (event.request.uri === '/.well-known/fxa-client-configuration') {",
@@ -104,13 +106,15 @@ export class FrontendStack extends Stack {
                 "}",
             ].join("\n")),
         });
+    }
 
+    private buildDistribution(): Distribution {
         const distribution = new Distribution(this, "Distribution", {
             defaultBehavior: {
                 origin: S3BucketOrigin.withOriginAccessControl(this.bucket),
                 viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                 functionAssociations: [{
-                    function: wellKnownFn,
+                    function: this.wellKnownFunction,
                     eventType: FunctionEventType.VIEWER_REQUEST,
                 }],
             },

--- a/lib/stacks/monitoring.ts
+++ b/lib/stacks/monitoring.ts
@@ -1,8 +1,10 @@
 import {MonitoringFacade} from "cdk-monitoring-constructs";
 import {Construct} from "constructs";
 
-import {Stack, StackProps} from "aws-cdk-lib";
+import {Duration, Stack, StackProps} from "aws-cdk-lib";
 import {SpecRestApi} from "aws-cdk-lib/aws-apigateway";
+import {Distribution, Function as CfFunction} from "aws-cdk-lib/aws-cloudfront";
+import {Metric} from "aws-cdk-lib/aws-cloudwatch";
 import {Table} from "aws-cdk-lib/aws-dynamodb";
 import {IFunction} from "aws-cdk-lib/aws-lambda";
 
@@ -10,9 +12,20 @@ import {StageType} from "../config";
 
 export interface MonitoringStackProps extends StackProps {
     stageType: StageType;
+    authApi: SpecRestApi;
+    authHandler: IFunction;
+    authTable: Table;
+    tokenApi: SpecRestApi;
+    tokenHandler: IFunction;
+    tokenUsersTable: Table;
+    tokenCacheTable: Table;
+    profileApi: SpecRestApi;
+    profileHandler: IFunction;
     storageApi: SpecRestApi;
     storageHandler: IFunction;
     storageTable: Table;
+    distribution: Distribution;
+    wellKnownFunction: CfFunction;
 }
 
 export class MonitoringStack extends Stack {
@@ -24,25 +37,120 @@ export class MonitoringStack extends Stack {
         this.props = props;
 
         this.monitoring = new MonitoringFacade(this, `FFSync-${this.props.stageType}`, {});
-        this.monitorApi();
+        this.monitorAuth();
+        this.monitorToken();
+        this.monitorProfile();
         this.monitorStorage();
+        this.monitorFrontend();
     }
 
-    private monitorApi(): void {
+    private monitorAuth(): void {
         this.monitoring
-            .addLargeHeader("API")
+            .addLargeHeader("Auth")
             .monitorApiGateway({
-                api: this.props.storageApi,
+                api: this.props.authApi,
                 apiStage: this.props.stageType.toLowerCase(),
             })
             .monitorLambdaFunction({
-                lambdaFunction: this.props.storageHandler,
+                lambdaFunction: this.props.authHandler,
+            })
+            .monitorDynamoTable({table: this.props.authTable});
+    }
+
+    private monitorToken(): void {
+        this.monitoring
+            .addLargeHeader("Token")
+            .monitorApiGateway({
+                api: this.props.tokenApi,
+                apiStage: this.props.stageType.toLowerCase(),
+            })
+            .monitorLambdaFunction({
+                lambdaFunction: this.props.tokenHandler,
+            })
+            .monitorDynamoTable({table: this.props.tokenUsersTable})
+            .monitorDynamoTable({table: this.props.tokenCacheTable});
+    }
+
+    private monitorProfile(): void {
+        this.monitoring
+            .addLargeHeader("Profile")
+            .monitorApiGateway({
+                api: this.props.profileApi,
+                apiStage: this.props.stageType.toLowerCase(),
+            })
+            .monitorLambdaFunction({
+                lambdaFunction: this.props.profileHandler,
             });
     }
 
     private monitorStorage(): void {
         this.monitoring
             .addLargeHeader("Storage")
+            .monitorApiGateway({
+                api: this.props.storageApi,
+                apiStage: this.props.stageType.toLowerCase(),
+            })
+            .monitorLambdaFunction({
+                lambdaFunction: this.props.storageHandler,
+            })
             .monitorDynamoTable({table: this.props.storageTable});
+    }
+
+    private monitorFrontend(): void {
+        const functionName = this.props.wellKnownFunction.functionName;
+        const cfFunctionDimensions = {FunctionName: functionName};
+
+        this.monitoring
+            .addLargeHeader("Frontend")
+            .monitorCloudFrontDistribution({
+                distribution: this.props.distribution,
+            })
+            .monitorCustom({
+                alarmFriendlyName: "CloudFront Function",
+                metricGroups: [
+                    {
+                        title: "CloudFront Function - Invocations & Errors",
+                        metrics: [
+                            new Metric({
+                                namespace: "AWS/CloudFront",
+                                metricName: "FunctionInvocations",
+                                dimensionsMap: cfFunctionDimensions,
+                                statistic: "Sum",
+                                period: Duration.minutes(5),
+                                label: "Invocations",
+                            }),
+                            new Metric({
+                                namespace: "AWS/CloudFront",
+                                metricName: "FunctionValidationErrors",
+                                dimensionsMap: cfFunctionDimensions,
+                                statistic: "Sum",
+                                period: Duration.minutes(5),
+                                label: "Validation Errors",
+                            }),
+                            new Metric({
+                                namespace: "AWS/CloudFront",
+                                metricName: "FunctionExecutionErrors",
+                                dimensionsMap: cfFunctionDimensions,
+                                statistic: "Sum",
+                                period: Duration.minutes(5),
+                                label: "Execution Errors",
+                            }),
+                        ],
+                    },
+                    {
+                        title: "CloudFront Function - Compute Utilization",
+                        metrics: [
+                            new Metric({
+                                namespace: "AWS/CloudFront",
+                                metricName: "FunctionComputeUtilization",
+                                dimensionsMap: cfFunctionDimensions,
+                                statistic: "Average",
+                                period: Duration.minutes(5),
+                                label: "Compute Utilization",
+                            }),
+                        ],
+                    },
+                ],
+            });
     }
 }


### PR DESCRIPTION
## Summary
- Expand the monitoring dashboard from storage-only to all 4 services (auth, token, profile, storage) with their respective API Gateways, Lambdas, and DynamoDB tables
- Add a Frontend section monitoring the CloudFront distribution (request rate, error rates, cache hit ratio, bytes transferred) and the well-known CloudFront Function (invocations, validation/execution errors, compute utilization)
- Extract `buildWellKnownFunction()` in the frontend stack to expose the CloudFront Function for monitoring

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx cdk synth` produces valid templates
- [ ] Deploy to staging and verify all dashboard sections render in CloudWatch