### PR TITLE
fix: resolve profile 401 by including fxa_uid in JWT and adding OIDCSUB# lookup

### DIFF
--- a/lambda/src/routes/auth/account_login.py
+++ b/lambda/src/routes/auth/account_login.py
@@ -68,6 +68,9 @@ class AccountLoginRoute(BaseRoute):
 
         uid = account["uid"]
 
+        # Backfill OIDCSUB# lookup record if missing (for accounts created before this index)
+        self._account_manager.ensure_oidcsub_record(uid, account.get("oidcSub", ""))
+
         # Create session token (always)
         session_token = self._token_manager.create_session_token(uid)
 

--- a/lambda/src/routes/auth/oauth_token.py
+++ b/lambda/src/routes/auth/oauth_token.py
@@ -101,6 +101,7 @@ class OAuthTokenRoute(BaseRoute):
             scope=scope,
             ttl=ttl,
             client_id=client_id,
+            fxa_uid=uid,
         )
 
         # Create refresh token
@@ -162,6 +163,7 @@ class OAuthTokenRoute(BaseRoute):
             scope=scope,
             ttl=ttl,
             client_id=client_id,
+            fxa_uid=uid,
         )
 
         # Create new refresh token
@@ -216,6 +218,7 @@ class OAuthTokenRoute(BaseRoute):
             scope=scope,
             ttl=ttl,
             client_id=client_id,
+            fxa_uid=uid,
         )
 
         return Response(

--- a/lambda/src/routes/profile/get_profile.py
+++ b/lambda/src/routes/profile/get_profile.py
@@ -43,18 +43,27 @@ class GetProfileRoute(BaseRoute):
         except InvalidTokenError:
             return self._error(401, 110, "Invalid or expired token")
 
-        account = self._auth_account_manager.get_account_by_uid(claims.sub)
+        # Look up account by fxa_uid (from JWT) or fall back to oidcSub lookup
+        account = None
+        if claims.fxa_uid:
+            account = self._auth_account_manager.get_account_by_uid(claims.fxa_uid)
+        if account is None:
+            account = self._auth_account_manager.get_account_by_oidc_sub(claims.sub)
         if account is None:
             return self._error(401, 110, "Account not found")
 
+        uid = account["uid"]
         return Response(
             status_code=200,
             content_type="application/json",
             body=json.dumps(
                 {
+                    "uid": uid,
                     "email": account["email"],
-                    "uid": account["uid"],
                     "locale": "en-US",
+                    "avatar": "",
+                    "avatarDefault": True,
+                    "sub": uid,
                 }
             ),
         )

--- a/lambda/src/services/auth_account_manager.py
+++ b/lambda/src/services/auth_account_manager.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 _PK = "PK"
 ACCOUNT_PREFIX = "ACCOUNT"
 EMAIL_PREFIX = "EMAIL"
+OIDCSUB_PREFIX = "OIDCSUB"
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,10 @@ class AuthAccountManager:
         """Generate partition key for email lookup record"""
         return f"{EMAIL_PREFIX}#{email}"
 
+    def _oidcsub_pk(self, oidc_sub: str) -> str:
+        """Generate partition key for OIDC subject lookup record"""
+        return f"{OIDCSUB_PREFIX}#{oidc_sub}"
+
     @staticmethod
     def _normalize_email(email: str) -> str:
         """Normalize email: lowercase and strip whitespace"""
@@ -47,15 +52,16 @@ class AuthAccountManager:
         oidc_sub: str,
         key_rotation_secret: str = "",
     ) -> None:
-        """Create account and email lookup records.
+        """Create account, email lookup, and OIDC subject lookup records.
 
-        Stores two DynamoDB items in safe order:
+        Stores three DynamoDB items in safe order:
         1. EMAIL#{normalized_email} -- lookup record with uid (uniqueness constraint first)
-        2. ACCOUNT#{uid} -- full account record with all fields + verified=True, createdAt
+        2. OIDCSUB#{oidc_sub} -- reverse lookup from OIDC subject to uid
+        3. ACCOUNT#{uid} -- full account record with all fields + verified=True, createdAt
 
         Email is normalized (lowercased, stripped).
         EMAIL# record uses ConditionExpression to prevent duplicates.
-        If ACCOUNT# write fails, EMAIL# is cleaned up to prevent orphans.
+        If later writes fail, earlier records are cleaned up to prevent orphans.
 
         Args:
             uid: Account unique identifier (UUID hex)
@@ -86,7 +92,22 @@ class AuthAccountManager:
                 raise ValueError(f"Email already exists: {normalized_email}") from e
             raise
 
-        # Store ACCOUNT# record; clean up EMAIL# if this fails
+        # Store OIDCSUB# lookup record; clean up EMAIL# if this fails
+        try:
+            self.table.put_item(
+                Item={
+                    _PK: self._oidcsub_pk(oidc_sub),
+                    "uid": uid,
+                },
+            )
+        except Exception:
+            try:
+                self.table.delete_item(Key={_PK: self._email_pk(normalized_email)})
+            except Exception:
+                logger.exception("Failed to clean up EMAIL# record for %s", normalized_email)
+            raise
+
+        # Store ACCOUNT# record; clean up EMAIL# and OIDCSUB# if this fails
         try:
             self.table.put_item(
                 Item={
@@ -103,11 +124,12 @@ class AuthAccountManager:
                 }
             )
         except Exception:
-            # Clean up orphaned EMAIL# record
-            try:
-                self.table.delete_item(Key={_PK: self._email_pk(normalized_email)})
-            except Exception:
-                logger.exception("Failed to clean up EMAIL# record for %s", normalized_email)
+            # Clean up orphaned lookup records
+            for pk in [self._email_pk(normalized_email), self._oidcsub_pk(oidc_sub)]:
+                try:
+                    self.table.delete_item(Key={_PK: pk})
+                except Exception:
+                    logger.exception("Failed to clean up %s", pk)
             raise
 
     def get_account_by_email(self, email: str) -> Optional[dict]:
@@ -134,6 +156,48 @@ class AuthAccountManager:
         uid = response["Item"]["uid"]
 
         # Look up ACCOUNT# record
+        return self.get_account_by_uid(uid)
+
+    def ensure_oidcsub_record(self, uid: str, oidc_sub: str) -> None:
+        """Create OIDCSUB# lookup record if it doesn't already exist.
+
+        Used to backfill the index for accounts created before OIDCSUB# was added.
+        Uses a conditional write so it's safe to call on every login.
+        """
+        if not oidc_sub:
+            return
+        try:
+            self.table.put_item(
+                Item={
+                    _PK: self._oidcsub_pk(oidc_sub),
+                    "uid": uid,
+                },
+                ConditionExpression="attribute_not_exists(PK)",
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return  # Already exists, nothing to do
+            raise
+
+    def get_account_by_oidc_sub(self, oidc_sub: str) -> Optional[dict]:
+        """Look up account by OIDC subject identifier.
+
+        1. Get OIDCSUB#{oidc_sub} record
+        2. If found, get ACCOUNT#{uid} record
+        3. Return account dict or None
+
+        Args:
+            oidc_sub: OIDC subject identifier
+
+        Returns:
+            Account dict or None if not found
+        """
+        response = self.table.get_item(Key={_PK: self._oidcsub_pk(oidc_sub)})
+
+        if "Item" not in response:
+            return None
+
+        uid = response["Item"]["uid"]
         return self.get_account_by_uid(uid)
 
     def get_account_by_uid(self, uid: str) -> Optional[dict]:

--- a/lambda/src/services/jwt_service.py
+++ b/lambda/src/services/jwt_service.py
@@ -39,14 +39,16 @@ class JWTService:
         scope: str,
         ttl: int,
         client_id: Optional[str] = None,
+        fxa_uid: Optional[str] = None,
     ) -> str:
         """Sign a JWT using KMS.
 
         Args:
-            sub: Subject claim (user identifier).
+            sub: Subject claim (OIDC subject identifier).
             scope: OAuth scope string.
             ttl: Token time-to-live in seconds.
             client_id: Optional OAuth client ID.
+            fxa_uid: Optional internal FxA account uid for profile lookups.
 
         Returns:
             Compact JWT string (header.payload.signature).
@@ -64,6 +66,8 @@ class JWTService:
         }
         if client_id is not None:
             payload["client_id"] = client_id
+        if fxa_uid is not None:
+            payload["fxa_uid"] = fxa_uid
 
         header_b64 = self._b64url(json.dumps(header, separators=(",", ":")).encode())
         payload_b64 = self._b64url(json.dumps(payload, separators=(",", ":")).encode())

--- a/lambda/src/services/jwt_verifier.py
+++ b/lambda/src/services/jwt_verifier.py
@@ -78,6 +78,7 @@ class JWTVerifier:
             aud=payload.get("client_id", ""),
             exp=payload["exp"],
             iat=payload["iat"],
+            fxa_uid=payload.get("fxa_uid"),
         )
 
     @cached_property

--- a/lambda/src/shared/oidc.py
+++ b/lambda/src/shared/oidc.py
@@ -12,12 +12,13 @@ class OIDCTokenClaims(DataClassJsonMixin):
     OIDC token claims extracted from validated token
 
     Attributes:
-        sub: Subject (user identifier)
+        sub: Subject (OIDC subject identifier)
         iss: Issuer URL
         aud: Audience (client ID)
         exp: Expiry timestamp
         iat: Issued at timestamp
         email: User email (optional)
+        fxa_uid: Internal FxA account uid (optional, present in self-issued JWTs)
     """
 
     sub: str
@@ -26,6 +27,7 @@ class OIDCTokenClaims(DataClassJsonMixin):
     exp: int
     iat: int
     email: Optional[str] = None
+    fxa_uid: Optional[str] = None
 
 
 @dataclass

--- a/lambda/tests/routes/profile/test_get_profile.py
+++ b/lambda/tests/routes/profile/test_get_profile.py
@@ -30,11 +30,16 @@ def route(mock_jwt_verifier, mock_auth_account_manager):
 
 
 class TestGetProfile:
-    def test_valid_bearer_token_returns_200(
+    def test_valid_bearer_token_with_fxa_uid_returns_200(
         self, route, mock_jwt_verifier, mock_auth_account_manager
     ):
         mock_jwt_verifier.validate_token.return_value = OIDCTokenClaims(
-            sub="uid1", iss="https://auth.example.com", aud="client", exp=9999999999, iat=1000000000
+            sub="oidc-sub-123",
+            iss="https://auth.example.com",
+            aud="client",
+            exp=9999999999,
+            iat=1000000000,
+            fxa_uid="uid1",
         )
         mock_auth_account_manager.get_account_by_uid.return_value = {
             "uid": "uid1",
@@ -54,6 +59,37 @@ class TestGetProfile:
         assert body["email"] == "user@example.com"
         assert body["uid"] == "uid1"
         assert body["locale"] == "en-US"
+        assert body["avatarDefault"] is True
+        assert body["sub"] == "uid1"
+        mock_auth_account_manager.get_account_by_uid.assert_called_once_with("uid1")
+
+    def test_fallback_to_oidc_sub_lookup(self, route, mock_jwt_verifier, mock_auth_account_manager):
+        """When fxa_uid is absent (older token), fall back to oidcSub lookup."""
+        mock_jwt_verifier.validate_token.return_value = OIDCTokenClaims(
+            sub="oidc-sub-123",
+            iss="https://auth.example.com",
+            aud="client",
+            exp=9999999999,
+            iat=1000000000,
+        )
+        mock_auth_account_manager.get_account_by_uid.return_value = None
+        mock_auth_account_manager.get_account_by_oidc_sub.return_value = {
+            "uid": "uid1",
+            "email": "user@example.com",
+        }
+        event = APIGatewayProxyEvent(
+            {
+                "httpMethod": "GET",
+                "path": "/v1/profile",
+                "headers": {"authorization": "Bearer valid-jwt-token"},
+                "body": None,
+            }
+        )
+        response = route.handle(event)
+        assert response.status_code == 200
+        body = json.loads(response.body)
+        assert body["uid"] == "uid1"
+        mock_auth_account_manager.get_account_by_oidc_sub.assert_called_once_with("oidc-sub-123")
 
     def test_missing_auth_returns_401(self, route):
         event = APIGatewayProxyEvent(
@@ -110,6 +146,7 @@ class TestGetProfile:
             iat=1000000000,
         )
         mock_auth_account_manager.get_account_by_uid.return_value = None
+        mock_auth_account_manager.get_account_by_oidc_sub.return_value = None
         event = APIGatewayProxyEvent(
             {
                 "httpMethod": "GET",

--- a/lambda/tests/services/test_auth_account_manager.py
+++ b/lambda/tests/services/test_auth_account_manager.py
@@ -87,6 +87,19 @@ class TestAuthAccountManager:
             },
         )
 
+        # Stub put_item for OIDCSUB# record
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": {
+                    "PK": f"OIDCSUB#{sample_oidc_sub}",
+                    "uid": sample_uid,
+                },
+            },
+        )
+
         # Stub put_item for ACCOUNT# record
         dynamodb_stubber.add_response(
             "put_item",
@@ -145,6 +158,19 @@ class TestAuthAccountManager:
                     "uid": sample_uid,
                 },
                 "ConditionExpression": "attribute_not_exists(PK)",
+            },
+        )
+
+        # Stub put_item for OIDCSUB# record
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": {
+                    "PK": f"OIDCSUB#{sample_oidc_sub}",
+                    "uid": sample_uid,
+                },
             },
         )
 
@@ -209,6 +235,262 @@ class TestAuthAccountManager:
                 wrap_kb=sample_wrap_kb,
                 oidc_sub=sample_oidc_sub,
             )
+
+    def test_create_account_cleans_up_email_on_oidcsub_write_failure(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        sample_email,
+        sample_normalized_email,
+        sample_verify_hash,
+        sample_k_a,
+        sample_wrap_kb,
+        sample_oidc_sub,
+        mock_time,
+    ):
+        """If OIDCSUB# put fails, EMAIL# record is cleaned up"""
+        # Stub successful EMAIL# put
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": {
+                    "PK": f"EMAIL#{sample_normalized_email}",
+                    "uid": sample_uid,
+                },
+                "ConditionExpression": "attribute_not_exists(PK)",
+            },
+        )
+
+        # Stub OIDCSUB# put to fail
+        dynamodb_stubber.add_client_error(
+            "put_item",
+            service_error_code="InternalServerError",
+            service_message="Internal server error",
+        )
+
+        # Stub delete_item for EMAIL# cleanup
+        dynamodb_stubber.add_response(
+            "delete_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Key": {"PK": f"EMAIL#{sample_normalized_email}"},
+            },
+        )
+
+        with pytest.raises(ClientError):
+            manager.create_account(
+                uid=sample_uid,
+                email=sample_email,
+                verify_hash=sample_verify_hash,
+                k_a=sample_k_a,
+                wrap_kb=sample_wrap_kb,
+                oidc_sub=sample_oidc_sub,
+            )
+
+    def test_create_account_oidcsub_failure_with_email_cleanup_failure(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        sample_email,
+        sample_normalized_email,
+        sample_verify_hash,
+        sample_k_a,
+        sample_wrap_kb,
+        sample_oidc_sub,
+        mock_time,
+    ):
+        """If OIDCSUB# put fails and EMAIL# cleanup also fails, original error is raised"""
+        # Stub successful EMAIL# put
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": {
+                    "PK": f"EMAIL#{sample_normalized_email}",
+                    "uid": sample_uid,
+                },
+                "ConditionExpression": "attribute_not_exists(PK)",
+            },
+        )
+
+        # Stub OIDCSUB# put to fail
+        dynamodb_stubber.add_client_error(
+            "put_item",
+            service_error_code="InternalServerError",
+            service_message="Internal server error",
+        )
+
+        # Stub delete_item for EMAIL# cleanup to also fail
+        dynamodb_stubber.add_client_error(
+            "delete_item",
+            service_error_code="InternalServerError",
+            service_message="Cleanup also failed",
+        )
+
+        with pytest.raises(ClientError):
+            manager.create_account(
+                uid=sample_uid,
+                email=sample_email,
+                verify_hash=sample_verify_hash,
+                k_a=sample_k_a,
+                wrap_kb=sample_wrap_kb,
+                oidc_sub=sample_oidc_sub,
+            )
+
+    # -- ensure_oidcsub_record ------------------------------------------------
+
+    def test_ensure_oidcsub_record_creates_when_missing(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        sample_oidc_sub,
+    ):
+        """Creates OIDCSUB# record when it doesn't exist"""
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": {
+                    "PK": f"OIDCSUB#{sample_oidc_sub}",
+                    "uid": sample_uid,
+                },
+                "ConditionExpression": "attribute_not_exists(PK)",
+            },
+        )
+
+        manager.ensure_oidcsub_record(sample_uid, sample_oidc_sub)
+
+    def test_ensure_oidcsub_record_noop_when_exists(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        sample_oidc_sub,
+    ):
+        """No-op when OIDCSUB# record already exists"""
+        dynamodb_stubber.add_client_error(
+            "put_item",
+            service_error_code="ConditionalCheckFailedException",
+            service_message="The conditional request failed",
+        )
+
+        manager.ensure_oidcsub_record(sample_uid, sample_oidc_sub)
+
+    def test_ensure_oidcsub_record_raises_unexpected_error(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        sample_oidc_sub,
+    ):
+        """Unexpected errors are re-raised"""
+        dynamodb_stubber.add_client_error(
+            "put_item",
+            service_error_code="InternalServerError",
+            service_message="Internal server error",
+        )
+
+        with pytest.raises(ClientError):
+            manager.ensure_oidcsub_record(sample_uid, sample_oidc_sub)
+
+    def test_ensure_oidcsub_record_noop_when_empty_sub(
+        self,
+        manager,
+        sample_uid,
+    ):
+        """No-op when oidc_sub is empty"""
+        manager.ensure_oidcsub_record(sample_uid, "")
+
+    # -- get_account_by_oidc_sub ----------------------------------------------
+
+    def test_get_account_by_oidc_sub_returns_account(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+        sample_uid,
+        sample_normalized_email,
+        sample_verify_hash,
+        sample_k_a,
+        sample_wrap_kb,
+        sample_oidc_sub,
+    ):
+        """Test get_account_by_oidc_sub returns account for existing OIDC subject"""
+        # Stub get_item for OIDCSUB# record
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"OIDCSUB#{sample_oidc_sub}"},
+                    "uid": {"S": sample_uid},
+                }
+            },
+            {
+                "TableName": storage_table_name,
+                "Key": {"PK": f"OIDCSUB#{sample_oidc_sub}"},
+            },
+        )
+
+        # Stub get_item for ACCOUNT# record
+        dynamodb_stubber.add_response(
+            "get_item",
+            {
+                "Item": {
+                    "PK": {"S": f"ACCOUNT#{sample_uid}"},
+                    "email": {"S": sample_normalized_email},
+                    "uid": {"S": sample_uid},
+                    "verifyHash": {"S": sample_verify_hash},
+                    "kA": {"S": sample_k_a},
+                    "wrapKB": {"S": sample_wrap_kb},
+                    "oidcSub": {"S": sample_oidc_sub},
+                    "verified": {"BOOL": True},
+                    "createdAt": {"N": "1234567890000"},
+                }
+            },
+            {
+                "TableName": storage_table_name,
+                "Key": {"PK": f"ACCOUNT#{sample_uid}"},
+            },
+        )
+
+        result = manager.get_account_by_oidc_sub(sample_oidc_sub)
+        assert result is not None
+        assert result["uid"] == sample_uid
+        assert result["email"] == sample_normalized_email
+
+    def test_get_account_by_oidc_sub_returns_none_for_unknown(
+        self,
+        manager,
+        dynamodb_stubber,
+        storage_table_name,
+    ):
+        """Test get_account_by_oidc_sub returns None for unknown OIDC subject"""
+        oidc_sub = "unknown-oidc-sub"
+
+        dynamodb_stubber.add_response(
+            "get_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Key": {"PK": f"OIDCSUB#{oidc_sub}"},
+            },
+        )
+
+        result = manager.get_account_by_oidc_sub(oidc_sub)
+        assert result is None
 
     # -- get_account_by_email -------------------------------------------------
 
@@ -370,7 +652,7 @@ class TestAuthAccountManager:
 
         assert result is None
 
-    def test_create_account_cleans_up_email_on_account_write_failure(
+    def test_create_account_cleans_up_on_account_write_failure(
         self,
         manager,
         dynamodb_stubber,
@@ -384,7 +666,7 @@ class TestAuthAccountManager:
         sample_oidc_sub,
         mock_time,
     ):
-        """If ACCOUNT# put fails, the EMAIL# record is cleaned up"""
+        """If ACCOUNT# put fails, EMAIL# and OIDCSUB# records are cleaned up"""
         # Stub successful EMAIL# put
         dynamodb_stubber.add_response(
             "put_item",
@@ -396,6 +678,19 @@ class TestAuthAccountManager:
                     "uid": sample_uid,
                 },
                 "ConditionExpression": "attribute_not_exists(PK)",
+            },
+        )
+
+        # Stub successful OIDCSUB# put
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": {
+                    "PK": f"OIDCSUB#{sample_oidc_sub}",
+                    "uid": sample_uid,
+                },
             },
         )
 
@@ -416,6 +711,16 @@ class TestAuthAccountManager:
             },
         )
 
+        # Stub delete_item for OIDCSUB# cleanup
+        dynamodb_stubber.add_response(
+            "delete_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Key": {"PK": f"OIDCSUB#{sample_oidc_sub}"},
+            },
+        )
+
         with pytest.raises(ClientError):
             manager.create_account(
                 uid=sample_uid,
@@ -426,7 +731,7 @@ class TestAuthAccountManager:
                 oidc_sub=sample_oidc_sub,
             )
 
-    def test_create_account_cleans_up_email_even_if_cleanup_fails(
+    def test_create_account_cleans_up_even_if_cleanup_fails(
         self,
         manager,
         dynamodb_stubber,
@@ -440,7 +745,7 @@ class TestAuthAccountManager:
         sample_oidc_sub,
         mock_time,
     ):
-        """If ACCOUNT# put fails and EMAIL# cleanup also fails, the original error is raised"""
+        """If ACCOUNT# put fails and cleanup also fails, the original error is raised"""
         # Stub successful EMAIL# put
         dynamodb_stubber.add_response(
             "put_item",
@@ -455,6 +760,19 @@ class TestAuthAccountManager:
             },
         )
 
+        # Stub successful OIDCSUB# put
+        dynamodb_stubber.add_response(
+            "put_item",
+            {},
+            {
+                "TableName": storage_table_name,
+                "Item": {
+                    "PK": f"OIDCSUB#{sample_oidc_sub}",
+                    "uid": sample_uid,
+                },
+            },
+        )
+
         # Stub ACCOUNT# put to fail
         dynamodb_stubber.add_client_error(
             "put_item",
@@ -463,6 +781,13 @@ class TestAuthAccountManager:
         )
 
         # Stub delete_item for EMAIL# cleanup to also fail
+        dynamodb_stubber.add_client_error(
+            "delete_item",
+            service_error_code="InternalServerError",
+            service_message="Cleanup also failed",
+        )
+
+        # Stub delete_item for OIDCSUB# cleanup to also fail
         dynamodb_stubber.add_client_error(
             "delete_item",
             service_error_code="InternalServerError",

--- a/lambda/tests/services/test_jwt_service.py
+++ b/lambda/tests/services/test_jwt_service.py
@@ -110,6 +110,20 @@ class TestSignJWT:
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
         assert "client_id" not in payload
 
+    def test_payload_contains_fxa_uid(self, service):
+        token = service.sign_jwt(sub="oidc-sub", scope="openid", ttl=300, fxa_uid="uid1")
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (4 - len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        assert payload["fxa_uid"] == "uid1"
+
+    def test_payload_omits_fxa_uid_when_none(self, service):
+        token = service.sign_jwt(sub="user1", scope="openid", ttl=300)
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (4 - len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        assert "fxa_uid" not in payload
+
     def test_calls_kms_sign(self, service, mock_kms):
         service.sign_jwt(sub="user1", scope="openid", ttl=300)
         mock_kms.sign.assert_called_once()

--- a/lambda/tests/services/test_jwt_verifier.py
+++ b/lambda/tests/services/test_jwt_verifier.py
@@ -88,6 +88,22 @@ class TestJWTVerifier:
         assert claims.sub == "user123"
         assert claims.iss == "https://auth.example.com"
         assert claims.exp == now + 900
+        assert claims.fxa_uid is None
+
+    def test_fxa_uid_extracted_from_token(self, verifier, keypair):
+        private_key, _ = keypair
+        now = int(time.time())
+        payload = {
+            "sub": "oidc-sub-123",
+            "iss": "https://auth.example.com",
+            "iat": now,
+            "exp": now + 900,
+            "fxa_uid": "uid-abc123",
+        }
+        token = _sign_jwt(private_key, payload)
+        claims = verifier.validate_token(token)
+        assert claims.sub == "oidc-sub-123"
+        assert claims.fxa_uid == "uid-abc123"
 
     def test_expired_token_raises(self, verifier, keypair):
         private_key, _ = keypair

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -23,15 +23,7 @@ new GitHubOidcStack(app, "GitHubOidcStack", {
         stageType,
     });
 
-    new MonitoringStack(app, `Monitoring-${stageType.toLowerCase()}`, {
-        env,
-        stageType,
-        storageApi: serviceStack.storageApi,
-        storageHandler: serviceStack.storageHandler,
-        storageTable: serviceStack.storageTable,
-    });
-
-    new FrontendStack(app, `Frontend-${stageType.toLowerCase()}`, {
+    const frontendStack = new FrontendStack(app, `Frontend-${stageType.toLowerCase()}`, {
         env,
         stageType,
         authApiDomain: serviceStack.authApiDomain,
@@ -39,6 +31,25 @@ new GitHubOidcStack(app, "GitHubOidcStack", {
         profileApiDomain: serviceStack.profileApiDomain,
         oidcProviderUrl: serviceStack.oidcProviderUrlParam,
         clientId: serviceStack.clientIdParam,
+    });
+
+    new MonitoringStack(app, `Monitoring-${stageType.toLowerCase()}`, {
+        env,
+        stageType,
+        authApi: serviceStack.authApi,
+        authHandler: serviceStack.authHandler,
+        authTable: serviceStack.authTable,
+        tokenApi: serviceStack.tokenApi,
+        tokenHandler: serviceStack.tokenHandler,
+        tokenUsersTable: serviceStack.tokenUsersTable,
+        tokenCacheTable: serviceStack.tokenCacheTable,
+        profileApi: serviceStack.profileApi,
+        profileHandler: serviceStack.profileHandler,
+        storageApi: serviceStack.storageApi,
+        storageHandler: serviceStack.storageHandler,
+        storageTable: serviceStack.storageTable,
+        distribution: frontendStack.distribution,
+        wellKnownFunction: frontendStack.wellKnownFunction,
     });
 });
 

--- a/lib/stacks/frontend.ts
+++ b/lib/stacks/frontend.ts
@@ -37,6 +37,7 @@ export class FrontendStack extends Stack {
     private readonly bucket: Bucket;
     private readonly certificate: Certificate;
     public readonly distribution: Distribution;
+    public readonly wellKnownFunction: CfFunction;
 
     private get domainName(): string {
         return `${this.props.stageType.toLowerCase()}.${BASE_DOMAIN}`;
@@ -52,6 +53,7 @@ export class FrontendStack extends Stack {
         });
         this.bucket = this.buildBucket()
         this.certificate = this.buildCertificate();
+        this.wellKnownFunction = this.buildWellKnownFunction();
 
         this.distribution = this.buildDistribution();
     }
@@ -77,7 +79,7 @@ export class FrontendStack extends Stack {
         });
     }
 
-    private buildDistribution(): Distribution {
+    private buildWellKnownFunction(): CfFunction {
         const configJson = JSON.stringify({
             auth_server_base_url: `https://${this.props.authApiDomain}`,
             oauth_server_base_url: `https://${this.props.authApiDomain}`,
@@ -86,7 +88,7 @@ export class FrontendStack extends Stack {
             content_url: `https://${this.domainName}`,
         });
 
-        const wellKnownFn = new CfFunction(this, "WellKnownFunction", {
+        return new CfFunction(this, "WellKnownFunction", {
             code: FunctionCode.fromInline([
                 "function handler(event) {",
                 "  if (event.request.uri === '/.well-known/fxa-client-configuration') {",
@@ -104,13 +106,15 @@ export class FrontendStack extends Stack {
                 "}",
             ].join("\n")),
         });
+    }
 
+    private buildDistribution(): Distribution {
         const distribution = new Distribution(this, "Distribution", {
             defaultBehavior: {
                 origin: S3BucketOrigin.withOriginAccessControl(this.bucket),
                 viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                 functionAssociations: [{
-                    function: wellKnownFn,
+                    function: this.wellKnownFunction,
                     eventType: FunctionEventType.VIEWER_REQUEST,
                 }],
             },

--- a/lib/stacks/monitoring.ts
+++ b/lib/stacks/monitoring.ts
@@ -1,8 +1,10 @@
 import {MonitoringFacade} from "cdk-monitoring-constructs";
 import {Construct} from "constructs";
 
-import {Stack, StackProps} from "aws-cdk-lib";
+import {Duration, Stack, StackProps} from "aws-cdk-lib";
 import {SpecRestApi} from "aws-cdk-lib/aws-apigateway";
+import {Distribution, Function as CfFunction} from "aws-cdk-lib/aws-cloudfront";
+import {Metric} from "aws-cdk-lib/aws-cloudwatch";
 import {Table} from "aws-cdk-lib/aws-dynamodb";
 import {IFunction} from "aws-cdk-lib/aws-lambda";
 
@@ -10,9 +12,20 @@ import {StageType} from "../config";
 
 export interface MonitoringStackProps extends StackProps {
     stageType: StageType;
+    authApi: SpecRestApi;
+    authHandler: IFunction;
+    authTable: Table;
+    tokenApi: SpecRestApi;
+    tokenHandler: IFunction;
+    tokenUsersTable: Table;
+    tokenCacheTable: Table;
+    profileApi: SpecRestApi;
+    profileHandler: IFunction;
     storageApi: SpecRestApi;
     storageHandler: IFunction;
     storageTable: Table;
+    distribution: Distribution;
+    wellKnownFunction: CfFunction;
 }
 
 export class MonitoringStack extends Stack {
@@ -24,25 +37,120 @@ export class MonitoringStack extends Stack {
         this.props = props;
 
         this.monitoring = new MonitoringFacade(this, `FFSync-${this.props.stageType}`, {});
-        this.monitorApi();
+        this.monitorAuth();
+        this.monitorToken();
+        this.monitorProfile();
         this.monitorStorage();
+        this.monitorFrontend();
     }
 
-    private monitorApi(): void {
+    private monitorAuth(): void {
         this.monitoring
-            .addLargeHeader("API")
+            .addLargeHeader("Auth")
             .monitorApiGateway({
-                api: this.props.storageApi,
+                api: this.props.authApi,
                 apiStage: this.props.stageType.toLowerCase(),
             })
             .monitorLambdaFunction({
-                lambdaFunction: this.props.storageHandler,
+                lambdaFunction: this.props.authHandler,
+            })
+            .monitorDynamoTable({table: this.props.authTable});
+    }
+
+    private monitorToken(): void {
+        this.monitoring
+            .addLargeHeader("Token")
+            .monitorApiGateway({
+                api: this.props.tokenApi,
+                apiStage: this.props.stageType.toLowerCase(),
+            })
+            .monitorLambdaFunction({
+                lambdaFunction: this.props.tokenHandler,
+            })
+            .monitorDynamoTable({table: this.props.tokenUsersTable})
+            .monitorDynamoTable({table: this.props.tokenCacheTable});
+    }
+
+    private monitorProfile(): void {
+        this.monitoring
+            .addLargeHeader("Profile")
+            .monitorApiGateway({
+                api: this.props.profileApi,
+                apiStage: this.props.stageType.toLowerCase(),
+            })
+            .monitorLambdaFunction({
+                lambdaFunction: this.props.profileHandler,
             });
     }
 
     private monitorStorage(): void {
         this.monitoring
             .addLargeHeader("Storage")
+            .monitorApiGateway({
+                api: this.props.storageApi,
+                apiStage: this.props.stageType.toLowerCase(),
+            })
+            .monitorLambdaFunction({
+                lambdaFunction: this.props.storageHandler,
+            })
             .monitorDynamoTable({table: this.props.storageTable});
+    }
+
+    private monitorFrontend(): void {
+        const functionName = this.props.wellKnownFunction.functionName;
+        const cfFunctionDimensions = {FunctionName: functionName};
+
+        this.monitoring
+            .addLargeHeader("Frontend")
+            .monitorCloudFrontDistribution({
+                distribution: this.props.distribution,
+            })
+            .monitorCustom({
+                alarmFriendlyName: "CloudFront Function",
+                metricGroups: [
+                    {
+                        title: "CloudFront Function - Invocations & Errors",
+                        metrics: [
+                            new Metric({
+                                namespace: "AWS/CloudFront",
+                                metricName: "FunctionInvocations",
+                                dimensionsMap: cfFunctionDimensions,
+                                statistic: "Sum",
+                                period: Duration.minutes(5),
+                                label: "Invocations",
+                            }),
+                            new Metric({
+                                namespace: "AWS/CloudFront",
+                                metricName: "FunctionValidationErrors",
+                                dimensionsMap: cfFunctionDimensions,
+                                statistic: "Sum",
+                                period: Duration.minutes(5),
+                                label: "Validation Errors",
+                            }),
+                            new Metric({
+                                namespace: "AWS/CloudFront",
+                                metricName: "FunctionExecutionErrors",
+                                dimensionsMap: cfFunctionDimensions,
+                                statistic: "Sum",
+                                period: Duration.minutes(5),
+                                label: "Execution Errors",
+                            }),
+                        ],
+                    },
+                    {
+                        title: "CloudFront Function - Compute Utilization",
+                        metrics: [
+                            new Metric({
+                                namespace: "AWS/CloudFront",
+                                metricName: "FunctionComputeUtilization",
+                                dimensionsMap: cfFunctionDimensions,
+                                statistic: "Average",
+                                period: Duration.minutes(5),
+                                label: "Compute Utilization",
+                            }),
+                        ],
+                    },
+                ],
+            });
     }
 }


### PR DESCRIPTION
## Summary

- Include internal `fxa_uid` in JWT payload so the profile endpoint can look up accounts by uid
- Add `OIDCSUB#` reverse-lookup records (like existing `EMAIL#` pattern) as fallback for older tokens
- Backfill `OIDCSUB#` record during login for pre-existing accounts
- Enhance profile response to match real FxA format (`uid`, `email`, `locale`, `avatar`, `avatarDefault`, `sub`)

## Context

`GET /v1/profile` returned 401 "Account not found" on every request. The JWT `sub` claim was set to `oidcSub` (external OIDC identity), but the profile endpoint called `get_account_by_uid(claims.sub)` which looked up `ACCOUNT#{oidcSub}` — the account is stored at `ACCOUNT#{uid}` (a different random UUID).

## Files changed

| File | Change |
|---|---|
| `jwt_service.py` | Add optional `fxa_uid` param to `sign_jwt()` |
| `oauth_token.py` | Pass `fxa_uid=uid` in all 3 grant type flows |
| `oidc.py` | Add `fxa_uid` field to `OIDCTokenClaims` |
| `jwt_verifier.py` | Extract `fxa_uid` from JWT payload |
| `get_profile.py` | Look up by `fxa_uid` first, fall back to `oidcSub` lookup |
| `auth_account_manager.py` | Add `OIDCSUB#` record in `create_account()`, add `get_account_by_oidc_sub()` and `ensure_oidcsub_record()` |
| `account_login.py` | Backfill `OIDCSUB#` record on login |

## Test plan

- [x] 939 tests pass, 100% coverage
- [x] black, isort, flake8 clean
- [ ] Deploy and trigger sync from Firefox — profile should return 200
- [ ] Verify login backfills the OIDCSUB# record for existing account