### PR TITLE
fix: handle Decimal serialization in attached_clients response

### DIFF
--- a/lambda/src/routes/auth/account_attached_clients.py
+++ b/lambda/src/routes/auth/account_attached_clients.py
@@ -1,6 +1,5 @@
 """AccountAttachedClients route — GET /v1/account/attached_clients"""
 
-import json
 from typing import Sequence
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
@@ -8,6 +7,7 @@ from aws_lambda_powertools.event_handler.middlewares import BaseMiddlewareHandle
 
 from src.services.device_manager import DeviceManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import json_dumps
 
 
 class AccountAttachedClientsRoute(BaseRoute):
@@ -54,5 +54,5 @@ class AccountAttachedClientsRoute(BaseRoute):
         return Response(
             status_code=200,
             content_type="application/json",
-            body=json.dumps(clients),
+            body=json_dumps(clients),
         )

--- a/lambda/src/routes/auth/account_device.py
+++ b/lambda/src/routes/auth/account_device.py
@@ -8,6 +8,7 @@ from aws_lambda_powertools.event_handler.middlewares import BaseMiddlewareHandle
 
 from src.services.device_manager import DeviceManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import json_dumps
 
 
 class AccountDeviceRoute(BaseRoute):
@@ -35,5 +36,5 @@ class AccountDeviceRoute(BaseRoute):
         return Response(
             status_code=200,
             content_type="application/json",
-            body=json.dumps(device),
+            body=json_dumps(device),
         )

--- a/lambda/src/routes/auth/account_devices.py
+++ b/lambda/src/routes/auth/account_devices.py
@@ -1,6 +1,5 @@
 """AccountDevices route — GET /v1/account/devices"""
 
-import json
 from typing import Sequence
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response

--- a/lambda/src/routes/auth/account_devices.py
+++ b/lambda/src/routes/auth/account_devices.py
@@ -8,6 +8,7 @@ from aws_lambda_powertools.event_handler.middlewares import BaseMiddlewareHandle
 
 from src.services.device_manager import DeviceManager
 from src.shared.base_route import BaseRoute
+from src.shared.utils import json_dumps
 
 
 class AccountDevicesRoute(BaseRoute):
@@ -41,5 +42,5 @@ class AccountDevicesRoute(BaseRoute):
         return Response(
             status_code=200,
             content_type="application/json",
-            body=json.dumps(devices),
+            body=json_dumps(devices),
         )


### PR DESCRIPTION
## Summary

- DynamoDB returns numeric fields (`createdAt`, `lastAccessTime`) as `Decimal` objects, causing `TypeError: Object of type Decimal is not JSON serializable` in device-related endpoints
- Replaced `json.dumps` with the existing `json_dumps` utility (`src/shared/utils.py`) which uses `DecimalEncoder` to convert `Decimal` → `float`
- Affected routes:
  - `GET /v1/account/attached_clients`
  - `GET /v1/account/devices`
  - `POST /v1/account/device`

## Test plan

- [ ] All 1002 existing tests pass with 100% coverage
- [ ] Verify the three affected endpoints no longer raise `TypeError` for users with devices that have numeric timestamp fields